### PR TITLE
Fix error when highlighting JSON output

### DIFF
--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -67,7 +67,7 @@ abstract class HttpFromContainerSuite
           if (munitAnsiColors)
             json
               .replaceAll("""(\"\w+\") : """, Console.CYAN + "$1" + Console.RESET + " : ")
-              .replaceAll(""" : (\"\w+\")""", " : " + Console.YELLOW + "$1" + Console.RESET)
+              .replaceAll(""" : (\".*\")""", " : " + Console.YELLOW + "$1" + Console.RESET)
               .replaceAll(""" : (\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
               .replaceAll(""" : true""", " : " + Console.MAGENTA + "true" + Console.RESET)
               .replaceAll(""" : false""", " : " + Console.MAGENTA + "false" + Console.RESET)

--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -71,6 +71,7 @@ abstract class HttpFromContainerSuite
               .replaceAll(""" : (\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
               .replaceAll(""" : true""", " : " + Console.MAGENTA + "true" + Console.RESET)
               .replaceAll(""" : false""", " : " + Console.MAGENTA + "false" + Console.RESET)
+              .replaceAll(""" : null""", " : " + Console.MAGENTA + "null" + Console.RESET)
           else json
       )
 


### PR DESCRIPTION
This PRs ensure that all JSON strings are treated as such when highlighting, by matching `.*` instead of `\w+`.

Also applies a new highlighting to `null` values to match the same one used for boolean values.