### PR TITLE
Modify regex for pretty printing negative and floating points numbers

### DIFF
--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -68,7 +68,7 @@ abstract class HttpFromContainerSuite
             json
               .replaceAll("""(\"\w+\") : """, Console.CYAN + "$1" + Console.RESET + " : ")
               .replaceAll(""" : (\".*\")""", " : " + Console.YELLOW + "$1" + Console.RESET)
-              .replaceAll(""" : (-?\d+.\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
+              .replaceAll(""" : (-?\d+\.\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
               .replaceAll(""" : (-?\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
               .replaceAll(""" : true""", " : " + Console.MAGENTA + "true" + Console.RESET)
               .replaceAll(""" : false""", " : " + Console.MAGENTA + "false" + Console.RESET)

--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -68,7 +68,8 @@ abstract class HttpFromContainerSuite
             json
               .replaceAll("""(\"\w+\") : """, Console.CYAN + "$1" + Console.RESET + " : ")
               .replaceAll(""" : (\".*\")""", " : " + Console.YELLOW + "$1" + Console.RESET)
-              .replaceAll(""" : (\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
+              .replaceAll(""" : (-?\d+.\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
+              .replaceAll(""" : (-?\d+)""", " : " + Console.GREEN + "$1" + Console.RESET)
               .replaceAll(""" : true""", " : " + Console.MAGENTA + "true" + Console.RESET)
               .replaceAll(""" : false""", " : " + Console.MAGENTA + "false" + Console.RESET)
               .replaceAll(""" : null""", " : " + Console.MAGENTA + "null" + Console.RESET)


### PR DESCRIPTION
This PR modifies the regex used for pretty printer the output of the clues, for the cases of negative and floating point numbers.

Current status: 
![Captura de Pantalla 2021-02-25 a la(s) 10 31 13 a  m](https://user-images.githubusercontent.com/3316502/109137299-5530fa80-7759-11eb-9233-ac88bc151f0d.png)

After this PR:
![Captura de Pantalla 2021-02-25 a la(s) 10 50 15 a  m](https://user-images.githubusercontent.com/3316502/109137329-5f52f900-7759-11eb-9fd3-502cac75118d.png)
