### PR TITLE
Add repetition feature for tests

### DIFF
--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -149,10 +149,9 @@ abstract class HttpFromContainerSuite
     /** Allows to run the same test several times sequencially */
     def repeat(times: Int) = copy(repetitions = times.some)
 
-    /** Allows to run the tests in paralell */
-    def parallel = copy(runInParallel = true.some)
-
-    def parallel(maxParallel: Int) = copy(runInParallel = true.some, maxParallel = maxParallel.some)
+    /** Allows to run the tests in parallel */
+    def parallel(maxParallel: Int = 5 /* scalafix:ok */) = 
+      copy(runInParallel = true.some, maxParallel = maxParallel.some)
 
     /** Force the test to be executed just once */
     def doNotRepeat = copy(repetitions = None)

--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -23,7 +23,6 @@ import cats.syntax.all._
 import com.dimafeng.testcontainers.munit.TestContainerForAll
 import fs2.Stream
 import io.circe.parser.parse
-import munit.Assertions
 import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Uri

--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import com.dimafeng.testcontainers.munit.TestContainerForAll
 import fs2.Stream
 import io.circe.parser.parse
+import munit.Assertions
 import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Uri
@@ -150,11 +151,14 @@ abstract class HttpFromContainerSuite
       }
 
     /** Allows to run the same test several times sequencially */
-    def repeat(times: Int) = copy(repetitions = times.some)
+    def repeat(times: Int) =
+      if (times < 1) Assertions.fail("times must be > 0")
+      else copy(repetitions = times.some)
 
     /** Allows to run the tests in parallel */
-    def parallel(maxParallel: Int = 5 /* scalafix:ok */) = 
-      copy(runInParallel = true.some, maxParallel = maxParallel.some)
+    def parallel(maxParallel: Int = 5 /* scalafix:ok */ ) =
+      if (maxParallel < 1) Assertions.fail("maxParallel must be > 0")
+      else copy(maxParallel = maxParallel.some)
 
     /** Force the test to be executed just once */
     def doNotRepeat = copy(repetitions = None)

--- a/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
@@ -47,7 +47,7 @@ class HttpFromContainerSuiteSuite extends HttpFromContainerSuite {
     .alias("Stress Test")
     .repeat(reps)
     .parallel(10) { response =>
-      numTest.incrementAndGet()
+      numTest.increment()
       val expected = Json.arr(
         Json.obj("id" := 1, "body" := "foo", "published" := true),
         Json.obj("id" := 2, "body" := "bar", "published" := false)

--- a/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
@@ -47,7 +47,7 @@ class HttpFromContainerSuiteSuite extends HttpFromContainerSuite {
     .alias("Stress Test")
     .repeat(reps)
     .parallel(10) { response =>
-      numTest.increment()
+      numTest.incrementAndGet()
       val expected = Json.arr(
         Json.obj("id" := 1, "body" := "foo", "published" := true),
         Json.obj("id" := 2, "body" := "bar", "published" := false)


### PR DESCRIPTION
# What it is done in this PR?
This PR adds a new feature to the container tests which allows to run the same test multiple times both sequentially and in parallel.

The new flags added to the tests are:

- `repeat(times)`: Enable the repetition of the same test the number of `times` indicated.
- `parallel(maxParallel)`: Enable the parallel execution of the tests, executing the number of `maxParallel` test in parallel.
- `doNotRepeat`: Disable the repetition of the test.