### PR TITLE
Allow adding follow-up requests to tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,3 +30,4 @@ lazy val `http4s-munit-testcontainers` = module
   .settings(libraryDependencies += "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.3")
   .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.21.20" % Test)
   .settings(libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % Test)
+  .settings(libraryDependencies += "io.circe" %% "circe-generic" % "0.13.0" % Test)

--- a/modules/http4s-munit-testcontainers/src/test/resources/db.json
+++ b/modules/http4s-munit-testcontainers/src/test/resources/db.json
@@ -1,6 +1,7 @@
 {
   "posts": [
-    { "id": 1, "body": "foo", "published": true },
-    { "id": 2, "body": "bar", "published": false }
+    { "id": 1, "body": "First", "published": true },
+    { "id": 2, "body": "Second", "published": false },
+    { "id": 3, "body": "Third", "published": true }
   ]
 }

--- a/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
@@ -16,8 +16,6 @@
 
 package munit
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import com.dimafeng.testcontainers.munit.TestContainerForAll
 import io.circe.Json
 import io.circe.syntax._
@@ -39,43 +37,6 @@ class HttpFromContainerSuiteSuite extends HttpFromContainerSuite with TestContai
     )
 
     assertIO(response.as[Json], expected)
-  }
-
-  val reps                   = 1000
-  val numTest: AtomicInteger = new AtomicInteger(0)
-
-  test(GET(uri"posts"))
-    .alias("Stress Test")
-    .repeat(reps)
-    .parallel(10) { response =>
-      numTest.incrementAndGet()
-      val expected = Json.arr(
-        Json.obj("id" := 1, "body" := "foo", "published" := true),
-        Json.obj("id" := 2, "body" := "bar", "published" := false)
-      )
-      assertIO(response.as[Json], expected)
-
-    }
-
-  test("all individual tests in a stress test must be runned") {
-    assertEquals(numTest.get(), reps)
-  }
-
-  val numDoNotRepTest: AtomicInteger = new AtomicInteger(0)
-  test(GET(uri"posts"))
-    .alias("DoNotRepeat Test")
-    .doNotRepeat { response =>
-      numDoNotRepTest.incrementAndGet()
-      val expected = Json.arr(
-        Json.obj("id" := 1, "body" := "foo", "published" := true),
-        Json.obj("id" := 2, "body" := "bar", "published" := false)
-      )
-      assertIO(response.as[Json], expected)
-
-    }
-
-  test("tests with doNotRepeat flag must be just runned once") {
-    assertEquals(numDoNotRepTest.get(), 1)
   }
 
 }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
@@ -65,6 +65,30 @@ abstract class Http4sHttpRoutesSuite extends Http4sSuite[Unit] {
   override def http4sMUnitFunFixture: SyncIO[FunFixture[ContextRequest[IO, Unit] => Resource[IO, Response[IO]]]] =
     SyncIO.pure(FunFixture(_ => req => routes.orNotFound.run(req.req).to[Resource[IO, *]], _ => ()))
 
+  implicit class Http4sMUnitTestCreatorOps(private val testCreator: Http4sMUnitTestCreator) {
+
+    /**
+     * Provide a new request created from the response of the previous request. The
+     * alias entered as parameter will be used to construct the test's name.
+     *
+     * If this is the last `andThen` call, the response provided to the test will be
+     * the one obtained from executing this request
+     */
+    def andThen(alias: String)(f: Response[IO] => IO[Request[IO]]): Http4sMUnitTestCreator =
+      testCreator.copy(followingRequests =
+        testCreator.followingRequests :+ ((alias, f.andThen(_.map(ContextRequest((), _)))))
+      )
+
+    /**
+     * Provide a new request created from the response of the previous request.
+     *
+     * If this is the last `andThen` call, the response provided to the test will be
+     * the one obtained from executing this request
+     */
+    def andThen(f: Response[IO] => IO[Request[IO]]): Http4sMUnitTestCreator = andThen("")(f)
+
+  }
+
   /**
    * Declares a test for the provided request. That request will be executed using
    * the routes provided in `routes`.

--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -105,6 +105,7 @@ abstract class Http4sSuite[A: Show] extends CatsEffectSuite {
 
   case class Http4sMUnitTestCreator(
       request: ContextRequest[IO, A],
+      followingRequests: List[(String, Response[IO] => IO[ContextRequest[IO, A]])] = Nil,
       testOptions: TestOptions = TestOptions(""),
       config: Http4sMunitConfig = Http4sMunitConfig.default
   ) {

--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -39,23 +39,48 @@ abstract class Http4sSuite[A: Show] extends CatsEffectSuite {
   /**
    * Allows altering the name of the generated tests.
    *
-   * It will generate test names like:
+   * By default it will generate test names like:
    *
    * {{{
-   * test(GET(uri"users" / 42))               // GET -> users/42
-   * test(GET(uri"users")).alias("All users") // GET -> users (All users)
+   * // GET -> users/42
+   * test(GET(uri"users" / 42))
+   *
+   * // GET -> users (All users)
+   * test(GET(uri"users")).alias("All users")
+   *
+   * // GET -> users as user-1
+   * test(GET(uri"users").as("user-1"))
+   *
+   * // GET -> users - executed 10 times with 2 in parallel
+   * test(GET(uri"users")).repeat(10).parallel(2)
+   *
+   * // GET -> users (retrieve the list of users and get the first user from the list)
+   * test(GET(uri"users"))
+   *    .alias("retrieve the list of users")
+   *    .andThen("get the first user from the list")(_.as[List[User]].flatMap {
+   *      case Nil               => fail("The list of users should not be empty")
+   *      case (head: User) :: _ => GET(uri"users" / head.id.show)
+   *    })
    * }}}
    *
    * @param request the test's request
+   * @param followingRequests the following request' aliases
    * @param testOptions the options for the current test
+   * @param config the configuration for this test
    * @return the test's name
    */
   def http4sMUnitNameCreator(
       request: ContextRequest[IO, A],
+      followingRequests: List[String],
       testOptions: TestOptions,
       config: Http4sMunitConfig
   ): String = {
-    val clue = if (testOptions.name.nonEmpty) s" (${testOptions.name})" else ""
+    val clue = followingRequests.+:(testOptions.name).filter(_.nonEmpty) match {
+      case Nil                 => ""
+      case List(head)          => s" ($head)"
+      case List(first, second) => s" ($first and $second)"
+      case list                => s"${list.init.mkString(" (", ", ", ", and")} ${list.last})" // scalafix:ok
+    }
 
     val context = request.context match {
       case _: Unit => None
@@ -67,6 +92,7 @@ abstract class Http4sSuite[A: Show] extends CatsEffectSuite {
         s" - executed $rep times" + config.maxParallel.fold("")(paral => s" with $paral in parallel")
       case _ => ""
     }
+
     s"${request.req.method.name} -> ${Uri.decode(request.req.uri.renderString)}$clue${context.fold("")(" as " + _)}$reps"
   }
 
@@ -148,7 +174,9 @@ abstract class Http4sSuite[A: Show] extends CatsEffectSuite {
 
     def apply(body: Response[IO] => Any)(implicit loc: Location): Unit =
       http4sMUnitFunFixture.test(
-        testOptions.withName(http4sMUnitNameCreator(request, testOptions, config)).withLocation(loc)
+        testOptions
+          .withName(http4sMUnitNameCreator(request, followingRequests.map(_._1), testOptions, config))
+          .withLocation(loc)
       ) { client =>
         Stream
           .emits(1 to config.repetitions.getOrElse(1))

--- a/modules/http4s-munit/src/test/scala/munit/Http4sAuthedRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sAuthedRoutesSuiteSuite.scala
@@ -18,7 +18,6 @@ package munit
 
 import cats.effect.IO
 
-import org.http4s.AuthedRequest
 import org.http4s.AuthedRoutes
 import org.http4s.client.dsl.io._
 import org.http4s.dsl.io._
@@ -30,17 +29,6 @@ class Http4sAuthedRoutesSuiteSuite extends Http4sAuthedRoutesSuite[String] {
     case GET -> Root / "hello" as user        => Ok(s"$user: Hi")
     case GET -> Root / "hello" / name as user => Ok(s"$user: Hi $name")
   }
-
-  override def http4sMUnitNameCreator(
-      request: AuthedRequest[IO, String],
-      testOptions: TestOptions,
-      config: Http4sMunitConfig
-  ): String =
-    s"Test by ${request.context} - " + super.http4sMUnitNameCreator(
-      request,
-      testOptions,
-      config
-    )
 
   test(GET(uri"hello") -> "jose").alias("Test 1") { response =>
     assertIO(response.as[String], "jose: Hi")

--- a/modules/http4s-munit/src/test/scala/munit/Http4sHttpRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sHttpRoutesSuiteSuite.scala
@@ -18,7 +18,6 @@ package munit
 
 import cats.effect.IO
 
-import org.http4s.ContextRequest
 import org.http4s.HttpRoutes
 import org.http4s.client.dsl.io._
 import org.http4s.dsl.io._
@@ -30,13 +29,6 @@ class Http4sHttpRoutesSuiteSuite extends Http4sHttpRoutesSuite {
     case GET -> Root / "hello"        => Ok("Hi")
     case GET -> Root / "hello" / name => Ok(s"Hi $name")
   }
-
-  override def http4sMUnitNameCreator(
-      request: ContextRequest[IO, Unit],
-      testOptions: TestOptions,
-      config: Http4sMunitConfig
-  ): String =
-    "Test - " + super.http4sMUnitNameCreator(request, testOptions, config)
 
   test(GET(uri"hello")).alias("Test 1") { response =>
     assertIO(response.as[String], "Hi")

--- a/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
@@ -43,7 +43,7 @@ class LogsSuite extends FunSuite {
 
   private val thisFile = s"${sys.props("user.dir")}/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala"
 
-  test("test names are correctly generated from a request") {
+  test("test names are correctly generated from an Http4sMUnitTestCreator") {
     val obtained = execute[LogsSuite.SimpleSuite]
 
     val expected =
@@ -51,6 +51,10 @@ class LogsSuite extends FunSuite {
           |==> Success GET -> posts/1
           |==> Success GET -> posts/2 (get second post)
           |==> Success GET -> posts/3 - executed 12 times with 5 in parallel
+          |==> Success GET -> posts/1 (get first post)
+          |==> Success GET -> posts/1 (get first post and second post)
+          |==> Success GET -> posts/1 (get 1st post and 2nd secuentially)
+          |==> Success GET -> posts/1 (get first and second posts secuentially)
           |""".stripMargin
 
     assertNoDiff(obtained, expected)
@@ -146,6 +150,14 @@ object LogsSuite {
     test(GET(uri"posts" / "2")).alias("get second post")(_ => ())
 
     test(GET(uri"posts" / "3")).repeat(12).parallel()(_ => ())
+
+    test(GET(uri"posts" / "1")).alias("get first post")(_ => ())
+
+    test(GET(uri"posts" / "1")).alias("get first post").andThen("second post")(_ => GET(uri"posts" / "2"))(_ => ())
+
+    test(GET(uri"posts" / "1")).alias("get 1st post and 2nd secuentially").andThen(_ => GET(uri"posts" / "2"))(_ => ())
+
+    test(GET(uri"posts" / "1")).andThen("get first and second posts secuentially")(_ => GET(uri"posts" / "2"))(_ => ())
 
   }
 

--- a/modules/http4s-munit/src/test/scala/munit/ParallelSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/ParallelSuite.scala
@@ -1,0 +1,56 @@
+package munit
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import cats.effect.IO
+
+import org.http4s._
+import org.http4s.client.dsl.io._
+import org.http4s.dsl.io._
+import org.http4s.syntax.all._
+
+class ParallelSuite extends Http4sHttpRoutesSuite {
+
+  override val routes: HttpRoutes[IO] = HttpRoutes.pure(Response().withEntity("hello!"))
+
+  // `repeat`/`parallel`
+
+  {
+    val execution: AtomicInteger = new AtomicInteger(0)
+
+    test(GET(uri"it-does-not-mater"))
+      .repeat(1000)
+      .parallel(10) { response =>
+        execution.incrementAndGet()
+
+        assertIO(response.as[String], "hello!")
+      }
+
+    test("all individual tests in a stress test must be run") {
+      assertEquals(execution.get(), 1000)
+    }
+
+  }
+
+  // `doNotRepeat`
+
+  {
+    val executions: AtomicInteger = new AtomicInteger(0)
+
+    test(GET(uri"it-does-not-mater"))
+      .alias("under no circumstance this test should be repeated")
+      .repeat(1000)
+      .parallel(10)
+      .doNotRepeat { response =>
+        executions.incrementAndGet()
+
+        assertIO(response.as[String], "hello!")
+      }
+
+    test("tests using `doNotRepeat` flag must be run just once") {
+      assertEquals(executions.get(), 1)
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR provides a new `andThen` method to test-creators to provide following requests that are created with the information of the previous ones:

```scala
// GET -> posts (retrieve the list of posts, get the first post from the list, and delete it)
test(GET(uri"posts"))
  .alias("retrieve the list of posts")
  .andThen("get the first post from the list")(_.as[List[Post]].flatMap {
    case Nil               => fail("The list of posts should not be empty")
    case (head: Post) :: _ => GET(uri"posts" / head.id.show)
  })
  .andThen("delete it")(_.as[Post].flatMap { post =>
    DELETE(uri"posts" / post.id.show)
  }) { response =>
    assertEquals(response.status.code, 200)

    assertIO(response.as[Json], Json.obj())
  }
```