### PR TITLE
Keep executing multiple tests, even when an exception occurs

### DIFF
--- a/modules/http4s-munit/src/main/scala/munit/Http4sMUnitConfig.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sMUnitConfig.scala
@@ -24,7 +24,11 @@ package munit
   * @author Alejandro Hernández
   * @author José Gutiérrez
   */
-final case class Http4sMUnitConfig(repetitions: Option[Int], maxParallel: Option[Int])
+final case class Http4sMUnitConfig(
+    repetitions: Option[Int],
+    maxParallel: Option[Int],
+    showAllStackTraces: Option[Boolean]
+)
 
 object Http4sMUnitConfig {
 
@@ -36,7 +40,10 @@ object Http4sMUnitConfig {
     sys.props
       .get("http4s.munit.max.parallel")
       .orElse(sys.env.get("HTTP4S_MUNIT_MAX_PARALLEL"))
-      .map(_.toInt)
+      .map(_.toInt),
+    sys.props
+      .get("http4s.munit.showAllStackTraces")
+      .orElse(sys.env.get("HTTP4S_SHOW_ALL_STACK_TRACES"))
+      .map(_.toBoolean)
   )
-
 }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -157,15 +157,15 @@ abstract class Http4sSuite[A: Show] extends CatsEffectSuite {
     /** Allows to run the same test several times sequencially */
     def repeat(times: Int) =
       if (times < 1) Assertions.fail("times must be > 0")
-      else copy(config = Http4sMUnitConfig(times.some, config.maxParallel))
+      else copy(config = Http4sMUnitConfig(times.some, config.maxParallel, config.showAllStackTraces))
 
     /** Force the test to be executed just once */
-    def doNotRepeat = copy(config = Http4sMUnitConfig(None, None))
+    def doNotRepeat = copy(config = Http4sMUnitConfig(None, None, config.showAllStackTraces))
 
     /** Allows to run the tests in parallel */
     def parallel(maxParallel: Int = 5 /* scalafix:ok */ ) =
       if (maxParallel < 1) Assertions.fail("maxParallel must be > 0")
-      else copy(config = Http4sMUnitConfig(config.repetitions, maxParallel.some))
+      else copy(config = Http4sMUnitConfig(config.repetitions, maxParallel.some, config.showAllStackTraces))
 
     def apply(body: Response[IO] => Any)(implicit loc: Location): Unit =
       http4sMUnitFunFixture.test(


### PR DESCRIPTION
### Why

When multiple tests are executed, and one of them fails, the rest are not executed.

### What

- Fix to the stopping tests execution, if one fails.
- Add `showAllStackTraces` to config parameters, for showing all stack straces, in the case a test is failing.
- Add specs.