### PR TITLE
Ensure `http4s-async-http-client` is not forced as a dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,13 +15,13 @@ lazy val documentation = project
 
 lazy val `http4s-munit` = module
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.27")
-  .settings(libraryDependencies += "org.http4s" %% "http4s-async-http-client" % "0.21.25")
   .settings(libraryDependencies += "org.http4s" %% "http4s-client" % "0.21.25")
   .settings(libraryDependencies += "org.http4s" %% "http4s-dsl" % "0.21.25")
   .settings(libraryDependencies += "org.typelevel" %% "munit-cats-effect-2" % "1.0.5")
   .settings(libraryDependencies += "io.circe" %% "circe-parser" % "0.14.1")
   .settings(libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.5" % Test)
   .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.21.25" % Test)
+  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.21.25" % Test)
   .settings(libraryDependencies += "org.typelevel" %% "mouse" % "1.0.4" % Test)
   .settings(addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.0" cross CrossVersion.full))
 
@@ -29,5 +29,6 @@ lazy val `http4s-munit-testcontainers` = module
   .dependsOn(`http4s-munit`)
   .settings(libraryDependencies += "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.5")
   .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.21.25" % Test)
+  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.21.25" % Test)
   .settings(libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.5" % Test)
   .settings(libraryDependencies += "io.circe" %% "circe-generic" % "0.14.1" % Test)

--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -31,17 +31,26 @@ import org.http4s.Uri
   *
   * @example
   * {{{
+  * import scala.concurrent.ExecutionContext.global
+  *
+  * import cats.effect.IO
+  * import cats.effect.Resource
+  *
   * import com.dimafeng.testcontainers.ContainerDef
   * import com.dimafeng.testcontainers.GenericContainer
   * import com.dimafeng.testcontainers.munit.TestContainerForAll
   *
   * import org.http4s.Method.GET
+  * import org.http4s.client.Client
+  * import org.http4s.client.blaze.BlazeClientBuilder
   * import org.http4s.client.dsl.io._
   * import org.http4s.syntax.all._
   *
   * import org.testcontainers.containers.wait.strategy.Wait
   *
   * class HttpFromContainerSuiteSuite extends munit.HttpFromContainerSuite with TestContainerForAll {
+  *
+  *  override def http4sMUnitClient: Resource[IO, Client[IO]] = BlazeClientBuilder[IO](global).resource
   *
   *  override val containerDef = new ContainerDef {
   *

--- a/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
@@ -16,6 +16,10 @@
 
 package munit
 
+import scala.concurrent.ExecutionContext.global
+
+import cats.effect.IO
+import cats.effect.Resource
 import cats.syntax.all._
 
 import com.dimafeng.testcontainers.munit.TestContainerForAll
@@ -24,10 +28,14 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 import org.http4s.Method._
 import org.http4s.circe.CirceEntityCodec._
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.syntax.all._
 
 class HttpFromContainerSuiteSuite extends HttpFromContainerSuite with TestContainerForAll {
+
+  override def http4sMUnitClient: Resource[IO, Client[IO]] = BlazeClientBuilder[IO](global).resource
 
   override val containerDef = DummyHttpContainer.Def()
 

--- a/modules/http4s-munit/src/test/scala/munit/HttpSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/HttpSuiteSuite.scala
@@ -16,14 +16,23 @@
 
 package munit
 
+import scala.concurrent.ExecutionContext.global
+
+import cats.effect.IO
+import cats.effect.Resource
+
 import io.circe.Json
 import org.http4s.Method.GET
 import org.http4s.Uri
 import org.http4s.circe._
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.syntax.all._
 
 class HttpSuiteSuite extends HttpSuite {
+
+  override def http4sMUnitClient: Resource[IO, Client[IO]] = BlazeClientBuilder[IO](global).resource
 
   override def baseUri(): Uri = uri"https://api.github.com"
 


### PR DESCRIPTION
# What has been done in this PR?

Convert `HttpSuite#http4sMUnitClient` into an abstract member, that must be override by users.

# Why?

So we don't force a specific client implementation.