### PR TITLE
Update http4s to version 0.22.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Sometimes (mostly while using the `HttpSuite` or `HttpFromContainerSuite`) one t
 ```scala
 test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
-    .andThen("delete it")(_.as[String].flatMap { id =>
+    .andThen("delete it")(_.as[String].map { id =>
       DELETE(uri"posts" / id)
     }) { response =>
       assertEquals(response.status.code, 204)
@@ -268,7 +268,7 @@ test(GET(uri"users")).repeat(10).parallel(2)
 // GET -> posts?number=10 (look for the 10th post and delete it)
 test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
-    .andThen("delete it")(_.as[String].flatMap { id => DELETE(uri"posts" / id) })
+    .andThen("delete it")(_.as[String].map { id => DELETE(uri"posts" / id) })
 ```
 
 ### Body in failed assertions

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ test(GET(uri"hello")).doNotRepeat { response =>
 Sometimes (mostly while using the `HttpSuite` or `HttpFromContainerSuite`) one test needs some pre-condition in order to be executed (e.g., in order to test the deletion of a user, you need to create it first). In such cases, once the request has been passed to the `test` method, we can call `andThen` to provide nested requests from the response of the previous one:
 
 ```scala
-test(GET(uri"posts" +? ("number", 10)))
+test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
     .andThen("delete it")(_.as[String].flatMap { id =>
       DELETE(uri"posts" / id)
@@ -266,7 +266,7 @@ test(GET(uri"users")).alias("all users")
 test(GET(uri"users")).repeat(10).parallel(2)
 
 // GET -> posts?number=10 (look for the 10th post and delete it)
-test(GET(uri"posts" +? ("number", 10)))
+test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
     .andThen("delete it")(_.as[String].flatMap { id => DELETE(uri"posts" / id) })
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ import io.circe.Json
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
@@ -132,7 +132,7 @@ import cats.effect.Resource
 
 import org.http4s.dsl.io._
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.syntax.all._
 

--- a/build.sbt
+++ b/build.sbt
@@ -15,20 +15,20 @@ lazy val documentation = project
 
 lazy val `http4s-munit` = module
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29")
-  .settings(libraryDependencies += "org.http4s" %% "http4s-client" % "0.21.28")
-  .settings(libraryDependencies += "org.http4s" %% "http4s-dsl" % "0.21.28")
+  .settings(libraryDependencies += "org.http4s" %% "http4s-client" % "0.22.4")
+  .settings(libraryDependencies += "org.http4s" %% "http4s-dsl" % "0.22.4")
   .settings(libraryDependencies += "org.typelevel" %% "munit-cats-effect-2" % "1.0.5")
   .settings(libraryDependencies += "io.circe" %% "circe-parser" % "0.14.1")
   .settings(libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.5" % Test)
-  .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.21.28" % Test)
-  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.21.28" % Test)
+  .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.22.4" % Test)
+  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.22.4" % Test)
   .settings(libraryDependencies += "org.typelevel" %% "mouse" % "1.0.4" % Test)
   .settings(addCompilerPlugin(("org.typelevel" % "kind-projector" % "0.13.2").cross(CrossVersion.full)))
 
 lazy val `http4s-munit-testcontainers` = module
   .dependsOn(`http4s-munit`)
   .settings(libraryDependencies += "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.7")
-  .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.21.28" % Test)
-  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.21.28" % Test)
+  .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.22.4" % Test)
+  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.22.4" % Test)
   .settings(libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.5" % Test)
   .settings(libraryDependencies += "io.circe" %% "circe-generic" % "0.14.1" % Test)

--- a/docs/README.md
+++ b/docs/README.md
@@ -276,7 +276,7 @@ test(GET(uri"hello")).doNotRepeat { response =>
 Sometimes (mostly while using the `HttpSuite` or `HttpFromContainerSuite`) one test needs some pre-condition in order to be executed (e.g., in order to test the deletion of a user, you need to create it first). In such cases, once the request has been passed to the `test` method, we can call `andThen` to provide nested requests from the response of the previous one:
 
 ```scala mdoc:silent
-test(GET(uri"posts" +? ("number", 10)))
+test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
     .andThen("delete it")(_.as[String].flatMap { id =>
       DELETE(uri"posts" / id)
@@ -302,7 +302,7 @@ test(GET(uri"users")).alias("all users")
 test(GET(uri"users")).repeat(10).parallel(2)
 
 // GET -> posts?number=10 (look for the 10th post and delete it)
-test(GET(uri"posts" +? ("number", 10)))
+test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
     .andThen("delete it")(_.as[String].flatMap { id => DELETE(uri"posts" / id) })
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -278,7 +278,7 @@ Sometimes (mostly while using the `HttpSuite` or `HttpFromContainerSuite`) one t
 ```scala mdoc:silent
 test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
-    .andThen("delete it")(_.as[String].flatMap { id =>
+    .andThen("delete it")(_.as[String].map { id =>
       DELETE(uri"posts" / id)
     }) { response =>
       assertEquals(response.status.code, 204)
@@ -304,7 +304,7 @@ test(GET(uri"users")).repeat(10).parallel(2)
 // GET -> posts?number=10 (look for the 10th post and delete it)
 test(GET(uri"posts" +? ("number" -> 10)))
     .alias("look for the 10th post")
-    .andThen("delete it")(_.as[String].flatMap { id => DELETE(uri"posts" / id) })
+    .andThen("delete it")(_.as[String].map { id => DELETE(uri"posts" / id) })
 ```
 
 ### Body in failed assertions

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,7 @@ import io.circe.Json
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.dsl.io._
 import org.http4s.syntax.all._
@@ -147,7 +147,7 @@ import cats.effect.Resource
 
 import org.http4s.dsl.io._
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.syntax.all._
 

--- a/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/main/scala/munit/HttpFromContainerSuite.scala
@@ -41,7 +41,7 @@ import org.http4s.Uri
   *
   * import org.http4s.Method.GET
   * import org.http4s.client.Client
-  * import org.http4s.client.blaze.BlazeClientBuilder
+  * import org.http4s.blaze.client.BlazeClientBuilder
   * import org.http4s.client.dsl.io._
   * import org.http4s.syntax.all._
   *

--- a/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
@@ -43,11 +43,11 @@ class HttpFromContainerSuiteSuite extends HttpFromContainerSuite with TestContai
 
   test(GET(uri"posts"))
     .alias("retrieve the list of posts")
-    .andThen("get the first post from the list")(_.as[List[Post]].flatMap {
+    .andThen("get the first post from the list")(_.as[List[Post]].map {
       case Nil               => fail("The list of posts should not be empty")
       case (head: Post) :: _ => GET(uri"posts" / head.id.show)
     })
-    .andThen("delete it")(_.as[Post].flatMap { post =>
+    .andThen("delete it")(_.as[Post].map { post =>
       DELETE(uri"posts" / post.id.show)
     }) { response =>
       assertEquals(response.status.code, 200)

--- a/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
+++ b/modules/http4s-munit-testcontainers/src/test/scala/munit/HttpFromContainerSuiteSuite.scala
@@ -27,9 +27,9 @@ import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.http4s.Method._
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.circe.CirceEntityCodec._
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.syntax.all._
 

--- a/modules/http4s-munit/src/main/scala/munit/Http4sAuthedRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sAuthedRoutesSuite.scala
@@ -70,13 +70,13 @@ abstract class Http4sAuthedRoutesSuite[A: Show] extends Http4sSuite[AuthedReques
       config: Http4sMUnitConfig
   ): String = Http4sMUnitDefaults.http4sMUnitNameCreator(request, followingRequests, testOptions, config)
 
-  implicit class Request2AuthedRequest(request: IO[Request[IO]]) {
+  implicit class Request2AuthedRequest(request: Request[IO]) {
 
     /** Converts an `IO[Request[IO]]` into an `IO[AuthedRequest[IO, A]]` by providing the `A` context. */
-    def context(context: A): IO[AuthedRequest[IO, A]] = request.map(AuthedRequest(context, _))
+    def context(context: A): AuthedRequest[IO, A] = AuthedRequest(context, request)
 
     /** Converts an `IO[Request[IO]]` into an `IO[AuthedRequest[IO, A]]` by providing the `A` context. */
-    def ->(a: A): IO[AuthedRequest[IO, A]] = context(a)
+    def ->(a: A): AuthedRequest[IO, A] = context(a)
 
   }
 
@@ -106,6 +106,6 @@ abstract class Http4sAuthedRoutesSuite[A: Show] extends Http4sSuite[AuthedReques
     * }
     * }}}
     */
-  def test(request: IO[AuthedRequest[IO, A]]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request.unsafeRunSync())
+  def test(request: AuthedRequest[IO, A]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request)
 
 }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
@@ -97,6 +97,6 @@ abstract class Http4sHttpRoutesSuite extends Http4sSuite[Request[IO]] {
     * }
     * }}}
     */
-  def test(request: IO[Request[IO]]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request.unsafeRunSync())
+  def test(request: Request[IO]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request)
 
 }

--- a/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
@@ -42,7 +42,7 @@ import org.http4s.client.Client
   * import org.http4s.Uri
   * import org.http4s.circe._
   * import org.http4s.client.Client
-  * import org.http4s.client.blaze.BlazeClientBuilder
+  * import org.http4s.blaze.client.BlazeClientBuilder
   * import org.http4s.client.dsl.io._
   * import org.http4s.syntax.all._
   *

--- a/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
@@ -115,6 +115,6 @@ abstract class HttpSuite extends Http4sSuite[Request[IO]] with CatsEffectFunFixt
     * }
     * }}}
     */
-  def test(request: IO[Request[IO]]) = Http4sMUnitTestCreator(request.unsafeRunSync())
+  def test(request: Request[IO]) = Http4sMUnitTestCreator(request)
 
 }

--- a/modules/http4s-munit/src/test/scala/munit/Http4sAuthedRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sAuthedRoutesSuiteSuite.scala
@@ -30,11 +30,11 @@ class Http4sAuthedRoutesSuiteSuite extends Http4sAuthedRoutesSuite[String] {
     case GET -> Root / "hello" / name as user => Ok(s"$user: Hi $name")
   }
 
-  test(GET(uri"hello") -> "jose").alias("Test 1") { response =>
+  test(GET(uri"/hello") -> "jose").alias("Test 1") { response =>
     assertIO(response.as[String], "jose: Hi")
   }
 
-  test(GET(uri"hello" / "Jose").context("alex")).alias("Test 2") { response =>
+  test(GET(uri"/hello" / "Jose").context("alex")).alias("Test 2") { response =>
     assertIO(response.as[String], "alex: Hi Jose")
   }
 

--- a/modules/http4s-munit/src/test/scala/munit/Http4sHttpRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sHttpRoutesSuiteSuite.scala
@@ -30,11 +30,11 @@ class Http4sHttpRoutesSuiteSuite extends Http4sHttpRoutesSuite {
     case GET -> Root / "hello" / name => Ok(s"Hi $name")
   }
 
-  test(GET(uri"hello")).alias("Test 1") { response =>
+  test(GET(uri"/hello")).alias("Test 1") { response =>
     assertIO(response.as[String], "Hi")
   }
 
-  test(GET(uri"hello" / "Jose")).alias("Test 2") { response =>
+  test(GET(uri"/hello" / "Jose")).alias("Test 2") { response =>
     assertIO(response.as[String], "Hi Jose")
   }
 

--- a/modules/http4s-munit/src/test/scala/munit/HttpSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/HttpSuiteSuite.scala
@@ -24,9 +24,9 @@ import cats.effect.Resource
 import io.circe.Json
 import org.http4s.Method.GET
 import org.http4s.Uri
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.circe._
 import org.http4s.client.Client
-import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.client.dsl.io._
 import org.http4s.syntax.all._
 

--- a/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
@@ -19,6 +19,7 @@ package munit
 import scala.reflect.ClassTag
 
 import cats.effect.IO
+import cats.syntax.all._
 
 import sbt.testing.EventHandler
 import sbt.testing.TaskDef
@@ -151,11 +152,16 @@ object LogsSuite {
 
     test(GET(uri"posts" / "1")).alias("get first post")(_ => ())
 
-    test(GET(uri"posts" / "1")).alias("get first post").andThen("second post")(_ => GET(uri"posts" / "2"))(_ => ())
+    test(GET(uri"posts" / "1"))
+      .alias("get first post")
+      .andThen("second post")(_ => GET(uri"posts" / "2").pure[IO])(_ => ())
 
-    test(GET(uri"posts" / "1")).alias("get 1st post and 2nd secuentially").andThen(_ => GET(uri"posts" / "2"))(_ => ())
+    test(GET(uri"posts" / "1"))
+      .alias("get 1st post and 2nd secuentially")
+      .andThen(_ => GET(uri"posts" / "2").pure[IO])(_ => ())
 
-    test(GET(uri"posts" / "1")).andThen("get first and second posts secuentially")(_ => GET(uri"posts" / "2"))(_ => ())
+    test(GET(uri"posts" / "1"))
+      .andThen("get first and second posts secuentially")(_ => GET(uri"posts" / "2").pure[IO])(_ => ())
 
   }
 


### PR DESCRIPTION
# What has been done in this PR?

This PR includes the update to http4s version 0.22.x which involves:

- Breaking change: `test` method no longer receive `IO[Response[IO]]` but `Response[IO]` since now `Method.apply` methods return the `Response` object directly.
- Query params created with `+?` have be provided as a tuple (instead of a two-param application).
- URIs must start with `/` when creating the `test`.