### PR TITLE
Create `Header.Raw` constructor alias

### DIFF
--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -23,7 +23,9 @@ import cats.syntax.all._
 
 import fs2.Stream
 import io.circe.parser.parse
+import org.http4s.Header
 import org.http4s.Response
+import org.typelevel.ci.CIString
 
 /** Base class for all of the other suites using http4s' requests to test HTTP servers/routes.
   *
@@ -109,6 +111,13 @@ abstract class Http4sSuite[Request] extends CatsEffectSuite {
     * behaviour of a suite.
     */
   def http4sMUnitFunFixture: SyncIO[FunFixture[Request => Resource[IO, Response[IO]]]]
+
+  implicit final class CiStringHeaderOps(ci: CIString) {
+
+    /** Creates a `Header.Raw` value from a case-insensitive string. */
+    def :=(value: String): Header.Raw = Header.Raw(ci, value)
+
+  }
 
   case class Http4sMUnitTestCreator(
       request: Request,

--- a/modules/http4s-munit/src/test/scala/munit/CiStringHeaderOpsSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/CiStringHeaderOpsSuite.scala
@@ -1,0 +1,29 @@
+package munit
+
+import cats.effect.IO
+import cats.effect.SyncIO
+import cats.effect.kernel.Resource
+
+import org.http4s.Header
+import org.http4s.Response
+import org.typelevel.ci._
+
+class HeaderInterpolatorSuite extends Http4sSuite[String] {
+
+  override def http4sMUnitNameCreator(
+      request: String,
+      followingRequests: List[String],
+      testOptions: TestOptions,
+      config: Http4sMUnitConfig
+  ): String = fail("This should no be called")
+
+  override def http4sMUnitFunFixture: SyncIO[FunFixture[String => Resource[IO, Response[IO]]]] =
+    fail("This should no be called")
+
+  test("header interpolator creates a valid raw header") {
+    val header = ci"my-header" := "my-value"
+
+    assertEquals(header, Header.Raw(ci"my-header", "my-value"))
+  }
+
+}


### PR DESCRIPTION
Usage:

```scala
ci"my-header" := "my-value" // Header.Raw(ci"my-header", "my-value")
```