### PR TITLE
Remove support for http4s old versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,14 +12,6 @@ lazy val documentation = project
   .enablePlugins(MdocPlugin)
   .settings(mdocOut := file("."))
   .dependsOn(`http4s-munit-testcontainers` % "compile->test")
-  .settings(mdocVariables ++= {
-    val all = releases.value.filter(_.isPublished)
-
-    val `0.7.x` = all.filter(_.name.startsWith("v0.7.")).reverse.headOption.map(_.tag.substring(1)).getOrElse("")
-    val `0.8.x` = all.filter(_.name.startsWith("v0.8.")).reverse.headOption.map(_.tag.substring(1)).getOrElse("")
-
-    Map("VERSION_021x" -> `0.7.x`, "VERSION_022x" -> `0.8.x`)
-  })
 
 lazy val `http4s-munit` = module
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29")

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,11 +9,7 @@ Integration library between [MUnit](https://scalameta.org/munit/) and [http4s](h
 Add the following line to your `build.sbt` file:
 
 ```sbt
-libraryDependencies += "com.alejandrohdezma" %% "http4s-munit" % "@VERSION@" % Test) // if using http4s 0.23.x
-
-libraryDependencies += "com.alejandrohdezma" %% "http4s-munit" % "@VERSION_022x@" % Test) // if using http4s 0.22.x
-
-libraryDependencies += "com.alejandrohdezma" %% "http4s-munit" % "@VERSION_021x@" % Test) // if using http4s 0.21.x
+libraryDependencies += "com.alejandrohdezma" %% "http4s-munit" % "@VERSION@" % Test)
 ```
 
 ## Usage


### PR DESCRIPTION
This PR removes support (from the documentation for versions 0.22.x and 0.21.x of http4s).