### PR TITLE
Add `http4s-ember-client` as an optional dependency to avoid overriding `http4sMUnitClient` every time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val documentation = project
   .enablePlugins(MdocPlugin)
   .settings(mdocOut := file("."))
   .dependsOn(`http4s-munit-testcontainers` % "compile->test")
+  .settings(libraryDependencies += "org.http4s" %% "http4s-blaze-client" % "0.23.12")
   .settings(mdocVariables ++= {
     val all = releases.value.filter(_.isPublished)
 
@@ -25,11 +26,11 @@ lazy val `http4s-munit` = module
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29")
   .settings(libraryDependencies += "org.http4s" %% "http4s-client" % "0.23.12")
   .settings(libraryDependencies += "org.http4s" %% "http4s-dsl" % "0.23.12")
+  .settings(libraryDependencies += "org.http4s" %% "http4s-ember-client" % "0.23.12" % Optional)
   .settings(libraryDependencies += "org.typelevel" %% "munit-cats-effect-3" % "1.0.7")
   .settings(libraryDependencies += "io.circe" %% "circe-parser" % "0.14.2")
   .settings(libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.11" % Test)
   .settings(libraryDependencies += "org.http4s" %% "http4s-circe" % "0.23.12" % Test)
-  .settings(libraryDependencies += "org.http4s" %% "http4s-ember-client" % "0.23.12" % Test)
   .settings(addCompilerPlugin(("org.typelevel" % "kind-projector" % "0.13.2").cross(CrossVersion.full)))
 
 lazy val `http4s-munit-testcontainers` = module

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ class MyAuthedRoutesSuite extends munit.Http4sAuthedRoutesSuite[String] {
 ### Testing a remote HTTP server
 
 In the case you don't want to use static http4s routes, but a running HTTP server, you have available the `HttpSuite`. This suite behaves exactly the same as the previous ones except that you don't provide a `routes` object, but a `baseUri` with the URI of your HTTP server. Any `Request` added in tests will prepend
-this URI before making a call using a real http4s `Client` (that you'll have to provide using `http4sMUnitClient`).
+this URI before making a call using a real http4s `Client`. By default the library uses Ember as the client implementation (although you'll need to provide its dependency explicitly). If you want to use a different implementation just override `http4sMUnitClient`.
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
@@ -95,12 +95,12 @@ import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.client.dsl.io._
 import org.http4s.dsl.io._
-import org.http4s.ember.client.EmberClientBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 import org.http4s.syntax.all._
 
 class GitHubSuite extends munit.HttpSuite {
 
-  override def http4sMUnitClient: Resource[IO, Client[IO]] = EmberClientBuilder.default[IO].build
+  override def http4sMUnitClient: Resource[IO, Client[IO]] = BlazeClientBuilder[IO].resource
 
   override val baseUri: Uri = uri"https://api.github.com"
 

--- a/modules/http4s-munit/src/test/scala/munit/HttpSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/HttpSuiteSuite.scala
@@ -16,21 +16,14 @@
 
 package munit
 
-import cats.effect.IO
-import cats.effect.Resource
-
 import io.circe.Json
 import org.http4s.Method.GET
 import org.http4s.Uri
 import org.http4s.circe._
-import org.http4s.client.Client
 import org.http4s.client.dsl.io._
-import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.syntax.all._
 
 class HttpSuiteSuite extends HttpSuite {
-
-  override def http4sMUnitClient: Resource[IO, Client[IO]] = EmberClientBuilder.default[IO].build
 
   override def baseUri(): Uri = uri"https://api.github.com"
 


### PR DESCRIPTION
This allows simplifying usages by not needing to override `http4sMUnitClient` unless you want to use a different client.

For the default usage the user will still need to add the dependency for `http4s-ember-client` or the test will crash with:

```
==> X initializationError  java.lang.IllegalAccessException: To use `HttpSuite` you either need to
          add `http4s-ember-client` dependency or provide your own client implementation by 
          overriding `http4sMUnitClient`.
    at munit.HttpSuite.http4sMUnitClient(HttpSuite.scala:95)
    at munit.HttpSuite.http4sMUnitFunFixture(HttpSuite.scala:101)
    at munit.Http4sSuite$Http4sMUnitTestCreator.apply(Http4sSuite.scala:203)
```