### PR TITLE
Add `http4sMUnitNameCreatorReplacements` to simplify editing test names

### DIFF
--- a/modules/http4s-munit/src/main/scala/munit/Http4sAuthedRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sAuthedRoutesSuite.scala
@@ -64,7 +64,13 @@ abstract class Http4sAuthedRoutesSuite[A: Show] extends Http4sSuite[AuthedReques
       followingRequests: List[String],
       testOptions: TestOptions,
       config: Http4sMUnitConfig
-  ): String = Http4sMUnitDefaults.http4sMUnitNameCreator(request, followingRequests, testOptions, config)
+  ): String = Http4sMUnitDefaults.http4sMUnitNameCreator(
+    request,
+    followingRequests,
+    testOptions,
+    config,
+    http4sMUnitNameCreatorReplacements()
+  )
 
   implicit class Request2AuthedRequest(request: Request[IO]) {
 

--- a/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
@@ -65,7 +65,13 @@ abstract class Http4sHttpRoutesSuite extends Http4sSuite[Request[IO]] {
       testOptions: TestOptions,
       config: Http4sMUnitConfig
   ): String =
-    Http4sMUnitDefaults.http4sMUnitNameCreator(ContextRequest((), request), followingRequests, testOptions, config)
+    Http4sMUnitDefaults.http4sMUnitNameCreator(
+      ContextRequest((), request),
+      followingRequests,
+      testOptions,
+      config,
+      http4sMUnitNameCreatorReplacements()
+    )
 
   override def http4sMUnitFunFixture: SyncIO[FunFixture[Request[IO] => Resource[IO, Response[IO]]]] =
     SyncIO.pure(FunFixture(_ => req => routes.orNotFound.run(req).to[Resource[IO, *]], _ => ()))

--- a/modules/http4s-munit/src/main/scala/munit/Http4sMUnitDefaults.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sMUnitDefaults.scala
@@ -29,7 +29,8 @@ object Http4sMUnitDefaults {
       request: ContextRequest[IO, A],
       followingRequests: List[String],
       testOptions: TestOptions,
-      config: Http4sMUnitConfig
+      config: Http4sMUnitConfig,
+      replacements: Seq[(String, String)] = Nil
   ): String = {
     val clue = followingRequests.+:(testOptions.name).filter(_.nonEmpty) match {
       case Nil                 => ""
@@ -49,7 +50,12 @@ object Http4sMUnitDefaults {
       case _ => ""
     }
 
-    s"${request.req.method.name} -> ${Uri.decode(request.req.uri.renderString)}$clue${context.fold("")(" as " + _)}$reps"
+    val nameWithoutReplacements = s"${request.req.method.name} -> ${Uri.decode(request.req.uri.renderString)}" +
+      s"$clue${context.fold("")(" as " + _)}$reps"
+
+    replacements.foldLeft(nameWithoutReplacements) { case (name, (value, replacement)) =>
+      name.replaceAll(value, replacement)
+    }
   }
 
 }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -83,6 +83,9 @@ abstract class Http4sSuite[Request] extends CatsEffectSuite with Http4sDsl[IO] w
       config: Http4sMUnitConfig
   ): String
 
+  /** List of replacements that will be applied to the result of `http4sMUnitNameCreator` using `String#replaceAll` */
+  def http4sMUnitNameCreatorReplacements(): Seq[(String, String)] = Nil
+
   /** Returns the response as suite clues.
     *
     * This method is then used by `response.clues` extension method.

--- a/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
@@ -81,7 +81,13 @@ abstract class HttpSuite extends Http4sSuite[Request[IO]] with CatsEffectFunFixt
       testOptions: TestOptions,
       config: Http4sMUnitConfig
   ): String =
-    Http4sMUnitDefaults.http4sMUnitNameCreator(ContextRequest((), request), followingRequests, testOptions, config)
+    Http4sMUnitDefaults.http4sMUnitNameCreator(
+      ContextRequest((), request),
+      followingRequests,
+      testOptions,
+      config,
+      http4sMUnitNameCreatorReplacements()
+    )
 
   /** This client is used under the hood to execute the requests. */
   def http4sMUnitClient: Resource[IO, Client[IO]] = try


### PR DESCRIPTION
Adds a new `def http4sMUnitNameCreatorReplacements(): List[(String, String)]` that will be used to apply replacements to the result of `http4sMUnitNameCreator` (if using the default implementation).

**Before:**

```scala
override def http4sMUnitNameCreator(
    request: Request[IO],
    followingRequests: List[String],
    testOptions: TestOptions,
    config: Http4sMUnitConfig
): String =
    (dummy.books.indices.map(i => (s"book/$i", s"$${dummy.books($i)}"))
      .foldLeft(super.http4sMUnitNameCreator(request, followingRequests, testOptions, config)) {
        case (name, (value, replacement)) => name.replaceAll(value, replacement)
      }
      .replaceAll("/", " / ")
      .replaceAll("\\?", " +? ")
      .replaceAll("&", " +? ")
```

**After:**

```scala
def http4sMUnitNameCreatorReplacements(): Seq[(String, String)] =
    dummy.books.indices.map(i => s"book/$i" -> s"$${dummy.books($i)}") :+
      ("/" -> " / ") :+ ("\\?" -> " +? ") :+ ("&" -> " +? ")
```