### PR TITLE
add Http4sTestHttpRoutesSuite & Http4sTestAuthedRoutesSuite

### DIFF
--- a/modules/http4s-munit/src/main/scala/munit/Http4sAuthedRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sAuthedRoutesSuite.scala
@@ -82,7 +82,7 @@ abstract class Http4sAuthedRoutesSuite[A: Show] extends Http4sSuite[AuthedReques
 
   }
 
-  override def http4sMUnitFunFixture: SyncIO[FunFixture[ContextRequest[IO, A] => Resource[IO, Response[IO]]]] =
+  def http4sMUnitFunFixture: SyncIO[FunFixture[ContextRequest[IO, A] => Resource[IO, Response[IO]]]] =
     SyncIO.pure(FunFixture(_ => routes.orNotFound.run(_).to[Resource[IO, *]], _ => ()))
 
   /** Declares a test for the provided request. That request will be executed using the routes provided in `routes`.
@@ -108,6 +108,7 @@ abstract class Http4sAuthedRoutesSuite[A: Show] extends Http4sSuite[AuthedReques
     * }
     *   }}}
     */
-  def test(request: AuthedRequest[IO, A]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request)
+  def test(request: AuthedRequest[IO, A]): Http4sMUnitTestCreator =
+    Http4sMUnitTestCreator(request, http4sMUnitFunFixture)
 
 }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sHttpRoutesSuite.scala
@@ -73,7 +73,7 @@ abstract class Http4sHttpRoutesSuite extends Http4sSuite[Request[IO]] {
       http4sMUnitNameCreatorReplacements()
     )
 
-  override def http4sMUnitFunFixture: SyncIO[FunFixture[Request[IO] => Resource[IO, Response[IO]]]] =
+  def http4sMUnitFunFixture: SyncIO[FunFixture[Request[IO] => Resource[IO, Response[IO]]]] =
     SyncIO.pure(FunFixture(_ => req => routes.orNotFound.run(req).to[Resource[IO, *]], _ => ()))
 
   /** Declares a test for the provided request. That request will be executed using the routes provided in `routes`.
@@ -99,6 +99,6 @@ abstract class Http4sHttpRoutesSuite extends Http4sSuite[Request[IO]] {
     * }
     *   }}}
     */
-  def test(request: Request[IO]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request)
+  def test(request: Request[IO]): Http4sMUnitTestCreator = Http4sMUnitTestCreator(request, http4sMUnitFunFixture)
 
 }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -135,11 +135,6 @@ abstract class Http4sSuite[Request] extends CatsEffectSuite with Http4sDsl[IO] w
           else json
       )
 
-  /** Base fixture used to obtain a response from a request. Can be re-implemented if you want to override the default
-    * behaviour of a suite.
-    */
-  def http4sMUnitFunFixture: SyncIO[FunFixture[Request => Resource[IO, Response[IO]]]]
-
   implicit final class CiStringHeaderOps(ci: CIString) {
 
     /** Creates a `Header.Raw` value from a case-insensitive string. */
@@ -149,6 +144,7 @@ abstract class Http4sSuite[Request] extends CatsEffectSuite with Http4sDsl[IO] w
 
   case class Http4sMUnitTestCreator(
       request: Request,
+      http4sMUnitFunFixture: SyncIO[FunFixture[Request => Resource[IO, Response[IO]]]],
       followingRequests: List[(String, Response[IO] => IO[Request])] = Nil,
       testOptions: TestOptions = TestOptions(""),
       config: Http4sMUnitConfig = Http4sMUnitConfig.default

--- a/modules/http4s-munit/src/main/scala/munit/Http4sTestAuthedRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sTestAuthedRoutesSuite.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020-2022 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.Show
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.SyncIO
+import org.http4s.AuthedRequest
+import org.http4s.AuthedRoutes
+import org.http4s.ContextRequest
+import org.http4s.Request
+import org.http4s.Response
+
+/** Base class for suites testing per-test `AuthedRoutes`. * Ensure that a `Show` instance for the request's context
+  * type is in scope. This instance will be used to include the context's information in the test's name.
+  *
+  * @example
+  *   {{{
+  * import cats.effect.IO
+  *
+  * import org.http4s.AuthedRoutes
+  *
+  * class MyAuthedRoutesSuite extends munit.Http4sTestAuthedRoutesSuite[String] {
+  *
+  *   test(routes = AuthedRoutes.of { case GET -> Root / "hello" as user =>
+  *     Ok(user + " says Hi")
+  *   }).as("Jose")) { response =>
+  *     assertIO(response.as[String], "Jose says Hi")
+  *   }
+  *
+  * }
+  *   }}}
+  */
+abstract class Http4sTestAuthedRoutesSuite[A: Show] extends Http4sSuite[AuthedRequest[IO, A]] {
+
+  /** @inheritdoc */
+  override def http4sMUnitNameCreator(
+      request: AuthedRequest[IO, A],
+      followingRequests: List[String],
+      testOptions: TestOptions,
+      config: Http4sMUnitConfig
+  ): String = Http4sMUnitDefaults.http4sMUnitNameCreator(
+    request,
+    followingRequests,
+    testOptions,
+    config,
+    http4sMUnitNameCreatorReplacements()
+  )
+
+  implicit class Request2AuthedRequest(request: Request[IO]) {
+
+    /** Converts an `IO[Request[IO]]` into an `IO[AuthedRequest[IO, A]]` by providing the `A` context. */
+    def context(context: A): AuthedRequest[IO, A] = AuthedRequest(context, request)
+
+    /** Converts an `IO[Request[IO]]` into an `IO[AuthedRequest[IO, A]]` by providing the `A` context. */
+    def ->(a: A): AuthedRequest[IO, A] = context(a)
+
+  }
+
+  def http4sMUnitFunFixture(
+      routes: AuthedRoutes[A, IO]
+  ): SyncIO[FunFixture[ContextRequest[IO, A] => Resource[IO, Response[IO]]]] =
+    SyncIO.pure(FunFixture(_ => routes.orNotFound.run(_).to[Resource[IO, *]], _ => ()))
+
+  /** Declares a test for the provided routes and request.
+    *
+    * @example
+    *   {{{
+    * test(routes = AuthedRoutes.of { case GET -> Root / "users" / number =>
+    *   Ok(number)
+    * }(GET(uri"users" / 42)) { response =>
+    *     // test body
+    * }
+    *   }}}
+    * @example
+    *   {{{
+    * test(routes = AuthedRoutes.of { case req @ POST -> Root / "users" =>
+    *   Ok(req.as[String])
+    * }(POST(json, uri"users")).alias("Create a new user") { response =>
+    *     // test body
+    * }
+    *   }}}
+    * @example
+    *   {{{
+    * test(routes = AuthedRoutes.of { case GET -> Root / "users" / number =>
+    *   Ok(number)
+    * }(GET(uri"users" / 42)).flaky { response =>
+    *     // test body
+    * }
+    *   }}}
+    */
+  def test(routes: AuthedRoutes[A, IO])(request: AuthedRequest[IO, A]): Http4sMUnitTestCreator =
+    Http4sMUnitTestCreator(request, http4sMUnitFunFixture(routes))
+
+}

--- a/modules/http4s-munit/src/main/scala/munit/Http4sTestHttpRoutesSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sTestHttpRoutesSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020-2022 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.SyncIO
+
+import org.http4s.ContextRequest
+import org.http4s.HttpRoutes
+import org.http4s.Request
+import org.http4s.Response
+
+/** Base class for suites testing per-test `HttpRoutes`.
+  *
+  * @example
+  *   {{{
+  * import cats.effect.IO
+  *
+  * import org.http4s.HttpRoutes
+  *
+  * class MyHttpRoutesSuite extends munit.Http4sTestHttpRoutesSuite {
+  *
+  *   test(routes = HttpRoutes.of { case GET -> Root / "hello" =>
+  *     Ok("Hello!")
+  *   }(GET(uri"hello")) { response =>
+  *     assertIO(response.as[String], "Hello!")
+  *   }
+  *
+  * }
+  *   }}}
+  * @author
+  *   Jack Treble
+  */
+abstract class Http4sTestHttpRoutesSuite extends Http4sSuite[Request[IO]] {
+
+  /** @inheritdoc */
+  override def http4sMUnitNameCreator(
+      request: Request[IO],
+      followingRequests: List[String],
+      testOptions: TestOptions,
+      config: Http4sMUnitConfig
+  ): String =
+    Http4sMUnitDefaults.http4sMUnitNameCreator(
+      ContextRequest((), request),
+      followingRequests,
+      testOptions,
+      config,
+      http4sMUnitNameCreatorReplacements()
+    )
+
+  def http4sMUnitFunFixture(routes: HttpRoutes[IO]): SyncIO[FunFixture[Request[IO] => Resource[IO, Response[IO]]]] =
+    SyncIO.pure(FunFixture(_ => req => routes.orNotFound.run(req).to[Resource[IO, *]], _ => ()))
+
+  /** Declares a test for the provided routes and request.
+    *
+    * @example
+    *   {{{
+    * test(routes = HttpRoutes.of { case GET -> Root / "users" / number =>
+    *   Ok(number)
+    * }(GET(uri"users" / 42)) { response =>
+    *     // test body
+    * }
+    *   }}}
+    * @example
+    *   {{{
+    * test(routes = HttpRoutes.of { case req @ POST -> Root / "users" =>
+    *   Ok(req.as[String])
+    * }(POST(json, uri"users")).alias("Create a new user") { response =>
+    *     // test body
+    * }
+    *   }}}
+    * @example
+    *   {{{
+    * test(routes = HttpRoutes.of { case GET -> Root / "users" / number =>
+    *   Ok(number)
+    * }(GET(uri"users" / 42)).flaky { response =>
+    *     // test body
+    * }
+    *   }}}
+    */
+  def test(routes: HttpRoutes[IO])(request: Request[IO]): Http4sMUnitTestCreator = {
+    Http4sMUnitTestCreator(
+      request,
+      http4sMUnitFunFixture(routes)
+    )
+  }
+
+}

--- a/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/HttpSuite.scala
@@ -112,7 +112,7 @@ abstract class HttpSuite extends Http4sSuite[Request[IO]] with CatsEffectFunFixt
 
   }
 
-  override def http4sMUnitFunFixture: SyncIO[FunFixture[Request[IO] => Resource[IO, Response[IO]]]] =
+  def http4sMUnitFunFixture: SyncIO[FunFixture[Request[IO] => Resource[IO, Response[IO]]]] =
     ResourceFixture(http4sMUnitClient.map(client => req => client.run(req.withUri(baseUri().resolve(req.uri)))))
 
   /** Declares a test for the provided request. That request will be executed using the provided client in `httpClient`
@@ -139,6 +139,6 @@ abstract class HttpSuite extends Http4sSuite[Request[IO]] with CatsEffectFunFixt
     * }
     *   }}}
     */
-  def test(request: Request[IO]) = Http4sMUnitTestCreator(request)
+  def test(request: Request[IO]) = Http4sMUnitTestCreator(request, http4sMUnitFunFixture)
 
 }

--- a/modules/http4s-munit/src/test/scala/munit/CiStringHeaderOpsSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/CiStringHeaderOpsSuite.scala
@@ -33,9 +33,6 @@ class HeaderInterpolatorSuite extends Http4sSuite[String] {
       config: Http4sMUnitConfig
   ): String = fail("This should no be called")
 
-  override def http4sMUnitFunFixture: SyncIO[FunFixture[String => Resource[IO, Response[IO]]]] =
-    fail("This should no be called")
-
   test("header interpolator creates a valid raw header") {
     val header = ci"my-header" := "my-value"
 

--- a/modules/http4s-munit/src/test/scala/munit/Http4sTestAuthedRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sTestAuthedRoutesSuiteSuite.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020-2022 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import org.http4s.AuthedRoutes
+
+class Http4sTestAuthedRoutesSuiteSuite extends Http4sTestAuthedRoutesSuite[String] {
+
+  test(routes = AuthedRoutes.of { case GET -> Root / "hello" as user =>
+    Ok(s"$user: Hi")
+  })(GET(uri"/hello") -> "jose").alias("Test 1") { response =>
+    assertIO(response.as[String], "jose: Hi")
+  }
+
+  test(routes = AuthedRoutes.of { case GET -> Root / "hello" / name as user =>
+    Ok(s"$user: Hi $name")
+  })(GET(uri"/hello" / "Jose").context("alex")).alias("Test 2") { response =>
+    assertIO(response.as[String], "alex: Hi Jose")
+  }
+
+}

--- a/modules/http4s-munit/src/test/scala/munit/Http4sTestHttpRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sTestHttpRoutesSuiteSuite.scala
@@ -16,7 +16,10 @@
 
 package munit
 
+import cats.effect.IO
 import org.http4s.HttpRoutes
+import org.http4s.Status
+import cats.implicits._
 
 class Http4sTestHttpRoutesSuiteSuite extends Http4sTestHttpRoutesSuite {
 
@@ -34,6 +37,54 @@ class Http4sTestHttpRoutesSuiteSuite extends Http4sTestHttpRoutesSuite {
     }
   )(GET(uri"/hello" / "Jose")).alias("Test 2") { response =>
     assertIO(response.as[String], "Hi Jose")
+  }
+
+  // Real world test
+
+  trait Database {
+
+    def getUser(id: Int): IO[Option[String]]
+
+  }
+
+  def makeRoutes(database: Database): HttpRoutes[IO] = {
+    HttpRoutes.of { case GET -> Root / "user" / idStr =>
+      idStr.toIntOption match {
+        case Some(id) =>
+          database.getUser(id).flatMap {
+            case Some(username) => Ok(username)
+            case None           => NotFound("User not found")
+          }
+        case None => BadRequest("Id is not a number")
+      }
+    }
+  }
+
+  test(makeRoutes(new Database {
+
+    override def getUser(id: Int): IO[Option[String]] = IO(Some("Jack"))
+
+  }))(GET(uri"/user/1")).alias("Return Ok when user exists") { response =>
+    assertEquals(response.status, Status.Ok)
+    assertIO(response.as[String], "Jack")
+  }
+
+  test(makeRoutes(new Database {
+
+    override def getUser(id: Int): IO[Option[String]] = IO(None)
+
+  }))(GET(uri"/user/1")).alias("Return NotFound when user does not exist") { response =>
+    assertEquals(response.status, Status.NotFound)
+    assertIO(response.as[String], "User not found")
+  }
+
+  test(makeRoutes(new Database {
+
+    override def getUser(id: Int): IO[Option[String]] = IO(fail("should not be called"))
+
+  }))(GET(uri"/user/NaN")).alias("Return BadRequest when user id is not a number") { response =>
+    assertEquals(response.status, Status.BadRequest)
+    assertIO(response.as[String], "Id is not a number")
   }
 
 }

--- a/modules/http4s-munit/src/test/scala/munit/Http4sTestHttpRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sTestHttpRoutesSuiteSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020-2022 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import org.http4s.HttpRoutes
+
+class Http4sTestHttpRoutesSuiteSuite extends Http4sTestHttpRoutesSuite {
+
+  test(routes = HttpRoutes.of { case GET -> Root / "hello" =>
+    Ok("Hi")
+  })(GET(uri"/hello")).alias("Test 1") { response =>
+    assertIO(response.as[String], "Hi")
+  }
+
+  test(
+    routes = {
+      HttpRoutes.of { case GET -> Root / "hello" / name =>
+        Ok(s"Hi $name")
+      }
+    }
+  )(GET(uri"/hello" / "Jose")).alias("Test 2") { response =>
+    assertIO(response.as[String], "Hi Jose")
+  }
+
+}


### PR DESCRIPTION
Adding this allows for more granular route tests

Real world example can be found in Http4sTestHttpRoutesSuiteSuite - https://github.com/alejandrohdezma/http4s-munit/pull/246/commits/a495063edf261bb582a4ab99f7d347979f73e859