### PR TITLE
Create suite for testing classes using http4s' `Client`

### DIFF
--- a/modules/http4s-munit/src/main/scala/munit/ClientSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/ClientSuite.scala
@@ -1,0 +1,85 @@
+package munit
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.SyncIO
+
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.dsl.Http4sDslBinCompat
+
+/** Base class for suites testing classes that need a `Client` instance.
+  *
+  * It adds two extension methods to the `Client` companion object: `from` and `fixture`.
+  *
+  * See method docs for more information on how to use them.
+  *
+  * It also brings the http-dsl into scope, so you don't need to import it yourself.
+  *
+  * @example
+  *   {{{
+  * import cats.effect._
+  * import org.http4s.client.Client
+  *
+  * class PingService[F[_]: Async](client: Client[F]) {
+  *
+  *   def ping(): F[String] = client.expect[String]("ping")
+  *
+  * }
+  *
+  * class PingServiceSuite extends munit.ClientSuite {
+  *
+  *   val fixture = Client.fixture(client => Resource.pure(new PingService[IO](client)))
+  *
+  *   fixture {
+  *     case GET -> Root / "ping" => Ok("pong")
+  *   }.test("PingService.ping works") { service =>
+  *     val result = service.ping()
+  *
+  *     assertIO(result, "pong")
+  *   }
+  *
+  * }
+  *   }}}
+  *
+  * @author
+  *   Alejandro Hernández
+  */
+trait ClientSuite extends CatsEffectSuite with Http4sDslBinCompat[IO] {
+
+  implicit class ClientTypeOps(t: Client.type) {
+
+    /** Creates an http4s `Client` from a partial function representing routes (like those created with
+      * `HttpRoutes.of`).
+      *
+      * @example
+      *   {{{
+      * Client.from {
+      *     case GET -> Root / "ping" / id => Ok("pong")
+      * }
+      *   }}}
+      */
+    def from(pf: PartialFunction[Request[IO], IO[Response[IO]]]): Client[IO] =
+      Client.fromHttpApp(HttpApp[IO](r => pf.lift(r).getOrElse(fail("This should not be called", clues(r)))))
+
+    /** Creates an MUnit fixture that initializes some class that depends on an http4s `Client` for each test.
+      *
+      * @example
+      *   {{{
+      * val fixture = Client.fixture(PingService.create[F](_))
+      *
+      * fixture {
+      *     case GET -> Root / "ping" => Ok("pong")
+      * }.test("testing my service") { service =>
+      *     ...
+      * }
+      *   }}}
+      */
+    def fixture[A](
+        f: Client[IO] => Resource[IO, A]
+    ): PartialFunction[Request[IO], IO[Response[IO]]] => SyncIO[FunFixture[A]] =
+      pf => ResourceFixture(f(from(pf)))
+
+  }
+
+}

--- a/modules/http4s-munit/src/test/scala/munit/ClientSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/ClientSuiteSuite.scala
@@ -1,0 +1,25 @@
+package munit
+
+import cats.effect._
+
+import org.http4s.client.Client
+
+class ClientSuiteSuite extends ClientSuite {
+
+  class PingService[F[_]: Async](client: Client[F]) {
+
+    def ping(): F[String] = client.expect[String]("ping")
+
+  }
+
+  val fixture = Client.fixture(client => Resource.pure(new PingService[IO](client)))
+
+  fixture { case GET -> Root / "ping" =>
+    Ok("pong")
+  }.test("PingService.ping works") { service =>
+    val result = service.ping()
+
+    assertIO(result, "pong")
+  }
+
+}


### PR DESCRIPTION
This new suite type (`ClientSuite`) can be used to add tests for a class or algebra that uses a `Client` instance.

It adds two extension methods to the `Client` companion object: `from` and `fixture`.

`Client.from` lets you create a mocked client from a partial function representing routes:

```scala
import org.http4s.client.Client

class ClientSuiteSuite extends munit.ClientSuite {

  val client = Client.from {
    case GET -> Root / "ping" => Ok("pong")
  }

}
```

On the other hand, the class also provides another extension method: `Client.fixture`. This method is inteded to be used to easily create a fixture for testing a class that uses an http4s' `Client`.

Given an algebra like:

```scala
import cats.effect._
import org.http4s.client.Client

trait PingService[F[_]] {

  def ping(): F[String]

}

object PingService {

  def create[F[_]: Async](client: Client[F]) = Resource.pure(
    new PingService[F] {

      def ping(): F[String] = client.expect[String]("ping")

    }
  )

}
```

You can test it using `ClientSuite` like:

```scala
import cats.effect._
import org.http4s.client.Client

class PingServiceSuite extends munit.ClientSuite {

  val fixture = Client.fixture(PingService.create(_))

  fixture {
    case GET -> Root / "ping" => Ok("pong")
  }.test("PingService.ping works") { service =>
    val result = service.ping()

    assertIO(result, "pong")
  }

}
```