### PR TITLE
Reword default test name where there are following requests

### DIFF
--- a/modules/http4s-munit/src/main/scala/munit/Http4sMUnitDefaults.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sMUnitDefaults.scala
@@ -35,8 +35,8 @@ object Http4sMUnitDefaults {
     val clue = followingRequests.+:(testOptions.name).filter(_.nonEmpty) match {
       case Nil                 => ""
       case List(head)          => s" ($head)"
-      case List(first, second) => s" ($first and $second)"
-      case list                => s"${list.init.mkString(" (", ", ", ", and")} ${list.last})"
+      case List(first, second) => s" ($first and then $second)"
+      case list                => s"${list.init.mkString(" (", ", ", ", and then")} ${list.last})"
     }
 
     val context = request.context match {

--- a/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
@@ -47,7 +47,7 @@ class LogsSuite extends FunSuite {
           |==> Success GET -> posts/2 (get second post)
           |==> Success GET -> posts/3 - executed 12 times with 5 in parallel
           |==> Success GET -> posts/1 (get first post)
-          |==> Success GET -> posts/1 (get first post and second post)
+          |==> Success GET -> posts/1 (get first post and then second post)
           |==> Success GET -> posts/1 (get 1st post and 2nd secuentially)
           |==> Success GET -> posts/1 (get first and second posts secuentially)
           |""".stripMargin


### PR DESCRIPTION
So the test name appears as it reads on code (`and then` instead of `and`)