### PR TITLE
Expose the per-test client inside test bodies

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -33,10 +33,10 @@ import org.http4s._
 
 class MyHttpRoutesSuite extends munit.Http4sSuite {
 
-  override def http4sMUnitClientFixture = HttpRoutes.of[IO] {
+  override def http4sMUnitClientResource = HttpRoutes.of[IO] {
     case GET -> Root / "hello"        => Ok("Hi")
     case GET -> Root / "hello" / name => Ok(s"Hi $name")
-  }.orFail.asFixture
+  }.orFail.asClient
 
   test(GET(uri"hello" / "Jose")).alias("Say hello to Jose") { response =>
     assertIO(response.as[String], "Hi Jose")
@@ -53,6 +53,11 @@ class MyHttpRoutesSuite extends munit.Http4sSuite {
 ```
 
 The `test` method receives a `Request[IO]` object and when the test runs, it runs that request against the provided routes and let you assert the response.
+
+> The client comes from overriding `http4sMUnitClientResource` (a `Resource[IO, Client[IO]]`), built fresh per test by
+> default — override `http4sMUnitClientTestFixture` (for example with `ResourceSuiteLocalFixture`) to share one client
+> across the whole suite. The older `http4sMUnitClientFixture` and `asFixture` are deprecated in favour of
+> `http4sMUnitClientResource` and `asClient`.
 
 `http4s-munit` will automatically name your tests using the information of the provided `Request`. For example, for the test shown in the previous code snippet, the following will be shown when running the test:
 
@@ -81,12 +86,12 @@ class MyAuthedRoutesSuite extends munit.Http4sSuite {
 
   implicit val key: Key[String] = Key.newKey[IO, String].unsafeRunSync()
 
-  override def http4sMUnitClientFixture = AuthedRequest.fromContext[String].andThen {
+  override def http4sMUnitClientResource = AuthedRequest.fromContext[String].andThen {
     AuthedRoutes.of[String, IO] {
       case GET -> Root / "hello" as user        => Ok(s"$user: Hi")
       case GET -> Root / "hello" / name as user => Ok(s"$user: Hi $name")
     }
-  }.orFail.asFixture
+  }.orFail.asClient
 
   test(GET(uri"hello" / "Jose").context("alex")).alias("Say hello to Jose") { response =>
     assertIO(response.as[String], "alex: Hi Jose")
@@ -177,12 +182,12 @@ class PingServiceSuite extends munit.CatsEffectSuite with munit.Http4sMUnitSynta
 ### Testing a remote HTTP server
 
 In the case you don't want to use static http4s routes, but a running HTTP server,
-you just need to provide a real http4s' `Client` implementation under `http4sMUnitClient`.
+you just need to provide a real http4s' `Client` implementation under `http4sMUnitClientResource`.
 Every test request you write will be made using this client.
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
-import cats.effect.SyncIO
+import cats.effect.Resource
 
 import io.circe.Json
 import org.http4s.circe._
@@ -191,8 +196,8 @@ import org.http4s.ember.client.EmberClientBuilder
 
 class GitHubSuite extends munit.Http4sSuite {
 
-  override def http4sMUnitClientFixture: SyncIO[FunFixture[Client[IO]]] =
-    ResourceFunFixture(EmberClientBuilder.default[IO].build.map(_.withBaseUri(uri"https://api.github.com")))
+  override def http4sMUnitClientResource: Resource[IO, Client[IO]] =
+    EmberClientBuilder.default[IO].build.map(_.withBaseUri(uri"https://api.github.com"))
 
   test(GET(uri"users/gutiory")) { response =>
     assertEquals(response.status.code, 200)
@@ -205,11 +210,11 @@ class GitHubSuite extends munit.Http4sSuite {
 }
 ```
 
-> If you are making requests to the same server, you can override `http4sMUnitClientFixture` like:
+> If you are making requests to the same server, you can override `http4sMUnitClientResource` like:
 >
 > ```scala
-> override def http4sMUnitClientFixture: SyncIO[FunFixture[Client[IO]]] =
->   ResourceFunFixture(EmberClientBuilder.default[IO].build.map(_.withBaseUri(localhost.withPort(8080))))
+> override def http4sMUnitClientResource: Resource[IO, Client[IO]] =
+>   EmberClientBuilder.default[IO].build.map(_.withBaseUri(localhost.withPort(8080)))
 > ```
 
 ### Testing an HTTP server running inside a container
@@ -220,7 +225,7 @@ it:
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
-import cats.effect.SyncIO
+import cats.effect.Resource
 
 import com.dimafeng.testcontainers.GenericContainer
 import com.dimafeng.testcontainers.munit.fixtures.TestContainersFixtures
@@ -236,11 +241,10 @@ class TestContainersSuite extends munit.Http4sSuite with TestContainersFixtures 
     GenericContainer(dockerImage = "mendhak/http-https-echo", exposedPorts = List(80))
   }
 
-  override def munitFixtures = List(container)
+  override def munitFixtures = super.munitFixtures :+ container
 
-  override def http4sMUnitClientFixture: SyncIO[FunFixture[Client[IO]]] = ResourceFunFixture {
+  override def http4sMUnitClientResource: Resource[IO, Client[IO]] =
     EmberClientBuilder.default[IO].build.map(_.withBaseUri(localhost.withPort(container().mappedPort(80))))
-  }
 
   test(GET(uri"ping")) { response =>
     assertEquals(response.status.code, 200)
@@ -264,10 +268,9 @@ class TestContainersSuite extends munit.Http4sSuite {
 
   lazy val container = GenericContainer(dockerImage = "nginxdemos/hello", exposedPorts = List(80))
 
-  override def http4sMUnitClientFixture = ResourceFunFixture {
+  override def http4sMUnitClientResource =
     Resource.fromAutoCloseable(IO(container.start()).as(container)) >>
       EmberClientBuilder.default[IO].build.map(_.withBaseUri(localhost.withPort(container.mappedPort(80))))
-  }
 
   test(GET(uri"ping")) { response =>
     assertEquals(response.status.code, 200, response.clues)
@@ -280,12 +283,10 @@ class TestContainersSuite extends munit.Http4sSuite {
 
 ### Running an effect before running your test
 
-Sometimes (specially when you are testing against a real server) you need something to be
-run before running your test. On these cases, you can just create a
-`ResourceFunFixture[Client[IO]]` (in which you can add other effects) and run it with `test`.
-
-Essentially this is the same as just running `test` since it is just an alias for
-`http4sMUnitClientFixture.test`.
+Sometimes (especially when testing against a real server) you need to run some setup before each
+test — and tear it down afterwards. Register a `ResourceTestLocalFixture` in `munitFixtures`; it can
+use the suite's configured client through `http4sMUnitClient` (the library sets the client
+up first, so it is available there), and the test body then runs with that setup already in place.
 
 ```scala mdoc:reset:silent
 import cats.effect.IO
@@ -299,29 +300,29 @@ import org.http4s.circe._
 
 class MyBookstoreSuite extends munit.Http4sSuite {
 
-  def httpClient = EmberClientBuilder.default[IO].build
+  override def http4sMUnitClientResource = EmberClientBuilder.default[IO].build
 
-  override def http4sMUnitClientFixture = ResourceFunFixture(httpClient)
+  val book = ResourceTestLocalFixture(
+    "book",
+    Resource.make {
+      val newBook = Json.obj("name" := "The Lord Of The Rings")
 
-  ResourceFunFixture {
-    httpClient.flatTap { client =>
-      Resource.make {
-        val newBook = Json.obj("name":= "The Lord Of The Rings")
+      http4sMUnitClient
+        .expect[Json](POST(newBook, uri"http://localhost:8080/books"))
+        .flatMap(_.hcursor.get[Int]("id").liftTo[IO])
+    }(id => http4sMUnitClient.run(DELETE(uri"http://localhost:8080/books" / id)).use_)
+  )
 
-        client
-          .expect[Json](POST(newBook, uri"http://localhost:8080/books"))
-          .flatMap(_.hcursor.get[Int]("id").liftTo[IO])
-      } { id =>
-        client.run(DELETE(uri"http://localhost:8080/books" / id)).use_
-      }.as(client)
-    }
-  }.test(GET(uri"http://localhost:8080/books?q=Rings")) { response =>
+  override def munitFixtures = super.munitFixtures :+ book
+
+  test(GET(uri"http://localhost:8080/books?q=Rings")) { response =>
     assertEquals(response.status.code, 200, response.clues)
 
     val result = response.as[Json].map(_.hcursor.get[String]("name"))
 
     assertIO(result, Right("The Lord Of The Rings"), response.clues)
   }
+
 }
 ```
 
@@ -336,9 +337,9 @@ import org.http4s._
 
 class MyDeferredRequestSuite extends munit.Http4sSuite {
 
-  override def http4sMUnitClientFixture = HttpRoutes.of[IO] {
+  override def http4sMUnitClientResource = HttpRoutes.of[IO] {
     case GET -> Root / "hello" / name => Ok(s"Hi $name")
-  }.orFail.asFixture
+  }.orFail.asClient
 
   def loadUser: IO[String] = IO.pure("Jose")
 
@@ -351,6 +352,42 @@ class MyDeferredRequestSuite extends munit.Http4sSuite {
 
 Since the request is not available while naming the test, providing an alias is mandatory; `http4s-munit` will fail with a clear message if you forget it.
 
+### Using the client inside the test body
+
+The same `Client[IO]` used to run the request is available inside the test body — and inside any plain
+`test("...")` body — by calling `http4sMUnitClient`. Because it is the very same instance,
+stateful middleware (a `CookieJar`, a connection pool, ...) is shared between the request run by the
+DSL and any manual call you make:
+
+```scala mdoc:reset:silent
+import cats.effect.IO
+
+import org.http4s.HttpRoutes
+
+class MyClientSuite extends munit.Http4sSuite {
+
+  override def http4sMUnitClientResource = HttpRoutes.of[IO] {
+    case GET -> Root / "ping"  => Ok("pong")
+    case GET -> Root / "count" => Ok("42")
+  }.orFail.asClient
+
+  test(GET(uri"/ping")) { response =>
+    for {
+      _ <- assertIO(response.as[String], "pong")
+      _ <- assertIO(http4sMUnitClient.expect[String](GET(uri"/count")), "42")
+    } yield ()
+  }
+
+  test("the count endpoint works") {
+    assertIO(http4sMUnitClient.expect[String](GET(uri"/count")), "42")
+  }
+
+}
+```
+
+A request run with `withHttpApp` only redirects that single DSL request; `http4sMUnitClient` still
+returns the client built from `http4sMUnitClientResource`.
+
 ### Tagging your tests
 
 Once the request has been passed to the `test` method, we can tag our tests before implementing them:
@@ -362,10 +399,10 @@ import org.http4s._
 
 class MyHttpRoutesSuite extends munit.Http4sSuite {
 
-  override val http4sMUnitClientFixture = HttpRoutes.of[IO] {
+  override val http4sMUnitClientResource = HttpRoutes.of[IO] {
     case GET -> Root / "hello"        => Ok("Hi")
     case GET -> Root / "hello" / name => Ok(s"Hi $name")
-  }.orFail.asFixture
+  }.orFail.asClient
 
 }
 
@@ -492,8 +529,8 @@ import org.http4s._
 
 class MySuite extends munit.Http4sSuite {
 
-  override def http4sMUnitClientFixture =
-    HttpRoutes.of[IO] { case _ => Ok("""{"id": 1, "name": "Jose"}""") }.orFail.asFixture
+  override def http4sMUnitClientResource =
+    HttpRoutes.of[IO] { case _ => Ok("""{"id": 1, "name": "Jose"}""") }.orFail.asClient
 
   test(GET(uri"users"))(response => assertEquals(response.status.code, 204))
 
@@ -544,10 +581,9 @@ import org.typelevel.ci._
 
 class TestContainersSuite extends munit.Http4sSuite {
 
-  override def http4sMUnitClientFixture = ResourceFunFixture {
+  override def http4sMUnitClientResource =
     Resource.fromAutoCloseable(IO(container.start()).as(container)) >>
       EmberClientBuilder.default[IO].build.map(_.withBaseUri(localhost.withPort(container.mappedPort(80))))
-  }
 
   override def http4sMUnitResponseClueCreator(response: Response[IO]) = {
     val logs = response.headers

--- a/modules/http4s-munit/src/main/scala/munit/Http4sMUnitSyntax.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sMUnitSyntax.scala
@@ -62,7 +62,7 @@ trait Http4sMUnitSyntax extends Http4sDsl[IO] with Http4sClientDsl[IO] with AllS
       *
       * @example
       *   {{{
-      * val fixture = Client.fixture(PingService.create[F](_))
+      * val fixture = Client.partialFixture(client => Resource.pure(PingService.create(client)))
       *
       * fixture {
       *     case GET -> Root / "ping" => Ok("pong")
@@ -96,7 +96,7 @@ trait Http4sMUnitSyntax extends Http4sDsl[IO] with Http4sClientDsl[IO] with AllS
       *   {{{
       *   val myAuthedRoutes: AuthedRoutes[IO, A] = ???
       *
-      *   AuthedRequest.fromContext[A].andThen(myAuthedRoutes).orFail.asFixture
+      *   AuthedRequest.fromContext[A].andThen(myAuthedRoutes).orFail.asClient
       *   }}}
       */
     def fromContext[A: Key]: Kleisli[OptionT[IO, *], Request[IO], AuthedRequest[IO, A]] =
@@ -129,11 +129,15 @@ trait Http4sMUnitSyntax extends Http4sDsl[IO] with Http4sClientDsl[IO] with AllS
 
   }
 
-  implicit final class Http4sMUnitHttpAppOps[A](httpApp: HttpApp[IO]) {
+  implicit final class Http4sMUnitHttpAppOps(httpApp: HttpApp[IO]) {
+
+    /** Transforms this app into an http4s `Client` resource. */
+    def asClient: Resource[IO, Client[IO]] =
+      Client.fromHttpApp(httpApp).pure[Resource[IO, *]]
 
     /** Transforms the provided app into an http4s' `Client` fixture. */
-    def asFixture: SyncIO[FunFixture[Client[IO]]] =
-      ResourceFunFixture(Client.fromHttpApp(httpApp).pure[Resource[IO, *]])
+    @deprecated("Use `asClient` together with `http4sMUnitClientResource`", "3.0.0")
+    def asFixture: SyncIO[FunFixture[Client[IO]]] = ResourceFunFixture(asClient)
 
   }
 
@@ -146,6 +150,7 @@ trait Http4sMUnitSyntax extends Http4sDsl[IO] with Http4sClientDsl[IO] with AllS
     def withUpdatedUri(f: Uri => Uri): Client[IO] = Client(request => client.run(request.withUri(f(request.uri))))
 
     /** Transforms the provided client into a `FunFixture`. */
+    @deprecated("Override `http4sMUnitClientResource` instead", "3.0.0")
     def asFixture: SyncIO[FunFixture[Client[IO]]] = ResourceFunFixture(client.pure[Resource[IO, *]])
 
   }

--- a/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
+++ b/modules/http4s-munit/src/main/scala/munit/Http4sSuite.scala
@@ -16,7 +16,10 @@
 
 package munit
 
+import scala.annotation.nowarn
+
 import cats.effect.IO
+import cats.effect.Resource
 import cats.effect.SyncIO
 import cats.syntax.all._
 
@@ -75,8 +78,52 @@ trait Http4sSuite extends CatsEffectSuite with Http4sMUnitSyntax {
   def http4sMUnitResponseClueCreator(response: Response[IO]): Clues =
     clues(response.headers.show, response.status.show)
 
+  /** Resource that creates the client used to execute this suite's requests.
+    *
+    * It backs [[http4sMUnitClientTestFixture]] (by default a fresh client per test) and is available ambiently inside
+    * any test body through [[http4sMUnitClient]]. Both the request run by the `test(...)` DSL and any manual
+    * `client.run(...)` in the body share that same instance.
+    */
+  @nowarn("cat=deprecation")
+  def http4sMUnitClientResource: Resource[IO, Client[IO]] =
+    http4sMUnitClientFixture.to[IO].toResource.flatMap { fixture =>
+      Resource.make(IO.fromFuture(IO.blocking(fixture.setup(TestOptions("")))))(c =>
+        IO.fromFuture(IO.blocking(fixture.teardown(c)))
+      )
+    }
+
+  /** The fixture that provides the client to the `test(...)` DSL and to [[http4sMUnitClient]].
+    *
+    * Defaults to a `ResourceTestLocalFixture` (a fresh client per test). Override it (as an `override lazy val`) to
+    * change that, for example with a `ResourceSuiteLocalFixture` to create the client once and share it across the
+    * whole suite:
+    *
+    * {{{
+    * override lazy val http4sMUnitClientTestFixture =
+    *   ResourceSuiteLocalFixture("http4sMUnitClient", http4sMUnitClientResource)
+    * }}}
+    */
+  lazy val http4sMUnitClientTestFixture: AnyFixture[Client[IO]] = // scalafix:ok DisableSyntax.valInAbstract
+    ResourceTestLocalFixture("http4sMUnitClient", http4sMUnitClientResource)
+
+  /** The client used to run the current test's request.
+    *
+    * It is the same instance the `test(...)` DSL uses, so stateful middleware (a `CookieJar`, a connection pool, ...)
+    * is shared between the auto-run request and any manual `client.run(...)` in the body. Only valid inside a test
+    * body.
+    */
+  def http4sMUnitClient: Client[IO] = http4sMUnitClientTestFixture()
+
   /** Fixture that creates the client which will be used to execute this suite's requests. */
-  def http4sMUnitClientFixture: SyncIO[FunFixture[Client[IO]]]
+  @deprecated("Override `http4sMUnitClientResource` instead", "3.0.0")
+  def http4sMUnitClientFixture: SyncIO[FunFixture[Client[IO]]] =
+    ResourceFunFixture(
+      Resource.eval(
+        IO.raiseError(new NotImplementedError("Override `http4sMUnitClientResource` to provide the client"))
+      )
+    )
+
+  override def munitFixtures: Seq[AnyFixture[_]] = super.munitFixtures :+ http4sMUnitClientTestFixture
 
   implicit class ResponseCluesOps(private val response: Response[IO]) {
 
@@ -119,8 +166,8 @@ trait Http4sSuite extends CatsEffectSuite with Http4sMUnitSyntax {
 
     /** Allows overriding the app used when running this test.
       *
-      * When this method is called, the test ignores the fixture on `http4sMUnitClientFixture` and runs the request
-      * against the provided app.
+      * When this method is called, the request is run against the provided app instead of the client from
+      * [[http4sMUnitClientResource]]. Note that `http4sMUnitClient` still returns the latter, not this app.
       */
     def withHttpApp[A](httpApp: HttpApp[IO]): Http4sMUnitTestCreator = {
       val client = Client[IO](httpApp.run(_).toResource)
@@ -130,6 +177,8 @@ trait Http4sSuite extends CatsEffectSuite with Http4sMUnitSyntax {
 
   }
 
+  /** Declares a test for the provided request against the client built by the provided fixture. */
+  @deprecated("Override `http4sMUnitClientResource` and use the suite's `test` methods instead", "3.0.0")
   implicit final class ClientFunFixtureTestOps(fixture: SyncIO[FunFixture[Client[IO]]])
       extends SyncIOFunFixtureOps(fixture) {
 
@@ -213,7 +262,7 @@ trait Http4sSuite extends CatsEffectSuite with Http4sMUnitSyntax {
   def test(request: Request[IO]): Http4sMUnitTestCreator =
     Http4sMUnitTestCreator(
       request = Right(request),
-      executor = http4sMUnitClientFixture.test,
+      executor = options => body => test(options)(body(http4sMUnitClient)),
       nameCreator = http4sMUnitTestNameCreator,
       bodyPrettifier = http4sMUnitBodyPrettifier
     )
@@ -234,7 +283,7 @@ trait Http4sSuite extends CatsEffectSuite with Http4sMUnitSyntax {
   def test(request: IO[Request[IO]]): Http4sMUnitTestCreator =
     Http4sMUnitTestCreator(
       request = Left(request),
-      executor = http4sMUnitClientFixture.test,
+      executor = options => body => test(options)(body(http4sMUnitClient)),
       nameCreator = http4sMUnitTestNameCreator,
       bodyPrettifier = http4sMUnitBodyPrettifier
     )

--- a/modules/http4s-munit/src/test/scala/munit/DeprecatedClientApiSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/DeprecatedClientApiSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020-2026 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import scala.annotation.nowarn
+
+import cats.effect.IO
+
+import org.http4s.HttpRoutes
+
+@nowarn("cat=deprecation")
+class DeprecatedClientApiSuite extends Http4sSuite {
+
+  override def http4sMUnitClientFixture = HttpRoutes
+    .of[IO] { case GET -> Root / "hello" / name =>
+      Ok(s"Hi $name")
+    }
+    .orFail
+    .asFixture
+
+  test(GET(uri"/hello" / "Jose")) { response =>
+    assertIO(response.as[String], "Hi Jose")
+  }
+
+}

--- a/modules/http4s-munit/src/test/scala/munit/Http4sAuthedRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sAuthedRoutesSuiteSuite.scala
@@ -26,12 +26,12 @@ class Http4sAuthedRoutesSuiteSuite extends Http4sSuite {
 
   implicit val key: Key[String] = Key.newKey[IO, String].unsafeRunSync()
 
-  override def http4sMUnitClientFixture = AuthedRequest.fromContext.andThen {
+  override def http4sMUnitClientResource = AuthedRequest.fromContext.andThen {
     AuthedRoutes.of[String, IO] {
       case GET -> Root / "hello" as user        => Ok(s"$user: Hi")
       case GET -> Root / "hello" / name as user => Ok(s"$user: Hi $name")
     }
-  }.orFail.asFixture
+  }.orFail.asClient
 
   test(GET(uri"/hello").context("jose")).alias("Test 1") { response =>
     assertIO(response.as[String], "jose: Hi")

--- a/modules/http4s-munit/src/test/scala/munit/Http4sHttpRoutesSuiteSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sHttpRoutesSuiteSuite.scala
@@ -22,13 +22,13 @@ import org.http4s.HttpRoutes
 
 class Http4sHttpRoutesSuiteSuite extends Http4sSuite {
 
-  override def http4sMUnitClientFixture = HttpRoutes
+  override def http4sMUnitClientResource = HttpRoutes
     .of[IO] {
       case GET -> Root / "hello"        => Ok("Hi")
       case GET -> Root / "hello" / name => Ok(s"Hi $name")
     }
     .orFail
-    .asFixture
+    .asClient
 
   test(GET(uri"/hello")).alias("Test 1") { response =>
     assertIO(response.as[String], "Hi")

--- a/modules/http4s-munit/src/test/scala/munit/Http4sMUnitAmbientClientSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sMUnitAmbientClientSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-2026 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import cats.effect.IO
+import cats.syntax.all._
+
+import org.http4s.HttpRoutes
+import org.http4s.client.middleware.CookieJar
+
+class Http4sMUnitAmbientClientSuite extends Http4sSuite {
+
+  override def http4sMUnitClientResource = HttpRoutes
+    .of[IO] {
+      case GET -> Root / "login"        => Ok("ok").map(_.addCookie("sid", "abc"))
+      case req @ GET -> Root / "whoami" => Ok(req.cookies.find(_.name === "sid").map(_.content).getOrElse("anonymous"))
+      case GET -> Root / "ping"         => Ok("pong")
+    }
+    .orFail
+    .asClient
+    .evalMap(CookieJar.impl[IO](_))
+
+  test("the ambient client is usable from a plain test body") {
+    assertIO(http4sMUnitClient.expect[String](GET(uri"http://localhost/ping")), "pong")
+  }
+
+  test(GET(uri"http://localhost/login")).alias("the body shares the request's client (same CookieJar)") { _ =>
+    assertIO(http4sMUnitClient.expect[String](GET(uri"http://localhost/whoami")), "abc")
+  }
+
+  test("each test gets a fresh client (the cookie jar is empty)") {
+    assertIO(http4sMUnitClient.expect[String](GET(uri"http://localhost/whoami")), "anonymous")
+  }
+
+}

--- a/modules/http4s-munit/src/test/scala/munit/Http4sMUnitSuiteLocalClientSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/Http4sMUnitSuiteLocalClientSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020-2026 Alejandro Hernández <https://github.com/alejandrohdezma>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package munit
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import cats.effect.IO
+import cats.effect.Resource
+
+import org.http4s.HttpRoutes
+import org.http4s.client.Client
+
+class Http4sMUnitSuiteLocalClientSuite extends Http4sSuite {
+
+  val allocations = new AtomicInteger(0)
+
+  override def http4sMUnitClientResource =
+    Resource.eval(IO(allocations.incrementAndGet())).flatMap { _ =>
+      HttpRoutes.of[IO] { case GET -> Root / "ping" => Ok("pong") }.orFail.asClient
+    }
+
+  override lazy val http4sMUnitClientTestFixture: AnyFixture[Client[IO]] =
+    ResourceSuiteLocalFixture("http4sMUnitClient", http4sMUnitClientResource)
+
+  test(GET(uri"/ping")) { response =>
+    assertEquals(allocations.get(), 1)
+    assertIO(response.as[String], "pong")
+  }
+
+  test("the client is created once and shared across the whole suite") {
+    assertEquals(allocations.get(), 1)
+    assertIO(http4sMUnitClient.expect[String](GET(uri"/ping")), "pong")
+  }
+
+}

--- a/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/LogsSuite.scala
@@ -134,7 +134,7 @@ object LogsSuite {
 
   class SimpleSuite extends Http4sSuite {
 
-    override def http4sMUnitClientFixture = HttpApp.pure[IO](Response()).asFixture
+    override def http4sMUnitClientResource = HttpApp.pure[IO](Response()).asClient
 
     test(GET(uri"posts"))(_ => ())
 
@@ -163,7 +163,7 @@ object LogsSuite {
 
   class JsonSuite extends Http4sSuite {
 
-    override def http4sMUnitClientFixture = HttpApp.liftF[IO](Ok("""{"id": 1, "name": "Jose"}""")).asFixture
+    override def http4sMUnitClientResource = HttpApp.liftF[IO](Ok("""{"id": 1, "name": "Jose"}""")).asClient
 
     test(GET(uri"posts"))(r => assertEquals(r.status.code, 204))
 

--- a/modules/http4s-munit/src/test/scala/munit/ParallelSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/ParallelSuite.scala
@@ -25,7 +25,7 @@ import org.http4s._
 
 class ParallelSuite extends Http4sSuite {
 
-  override def http4sMUnitClientFixture = HttpApp.liftF[IO](Ok("hello!")).asFixture
+  override def http4sMUnitClientResource = HttpApp.liftF[IO](Ok("hello!")).asClient
 
   // `repeat`/`parallel`
 

--- a/modules/http4s-munit/src/test/scala/munit/RealWorldTest.scala
+++ b/modules/http4s-munit/src/test/scala/munit/RealWorldTest.scala
@@ -17,6 +17,7 @@
 package munit
 
 import cats.effect.IO
+import cats.effect.Resource
 import cats.syntax.all._
 
 import org.http4s.HttpRoutes
@@ -25,7 +26,7 @@ import org.http4s.client.Client
 
 class RealWorldTest extends Http4sSuite {
 
-  override def http4sMUnitClientFixture = Client.fail.asFixture
+  override def http4sMUnitClientResource = Client.fail.pure[Resource[IO, *]]
 
   trait Database {
 

--- a/modules/http4s-munit/src/test/scala/munit/TestContainersSuite.scala
+++ b/modules/http4s-munit/src/test/scala/munit/TestContainersSuite.scala
@@ -30,10 +30,9 @@ class TestContainersSuite extends munit.Http4sSuite {
   lazy val container = GenericContainer(dockerImage = "nginxdemos/hello", exposedPorts = List(80))
 
   /** This will start/stop a hello server before/after every test */
-  override def http4sMUnitClientFixture = ResourceFunFixture {
+  override def http4sMUnitClientResource =
     Resource.fromAutoCloseable(IO(container.start()).as(container)) >>
       EmberClientBuilder.default[IO].build.map(_.withUpdatedUri(localhost.withPort(container.mappedPort(80)).resolve))
-  }
 
   override def http4sMUnitResponseClueCreator(response: Response[IO]) = {
     val logs = response.headers


### PR DESCRIPTION
`http4sMUnitClient: Client[IO]` makes the client used to run a `test(...)` request reachable inside any test body, including plain `test("name")` bodies, as the same instance. Stateful middleware such as a `CookieJar` is therefore shared between the auto-run request and any manual `client.run(...)`.

The client is configured by overriding `http4sMUnitClientResource: Resource[IO, Client[IO]]` and is provided per test through `http4sMUnitClientTestFixture`, which can be overridden (for example with `ResourceSuiteLocalFixture`) to create a single client for the whole suite.

### Backward compatibility

Source- and binary-compatible. `http4sMUnitClientFixture` (and `HttpApp#asFixture`, `Client#asFixture`, `ClientFunFixtureTestOps`) are kept and deprecated; `http4sMUnitClientResource` falls back to the deprecated fixture, so existing suites keep working with only a deprecation warning.
